### PR TITLE
Fix issue on File Explorer

### DIFF
--- a/res/app/control-panes/explorer/explorer-controller.js
+++ b/res/app/control-panes/explorer/explorer-controller.js
@@ -1,3 +1,7 @@
+/**
+* Copyright © 2020 contains code contributed by Orange SA, authors: Denis Barbaron - Licensed under the Apache license 2.0
+**/
+
 module.exports = function ExplorerCtrl($scope) {
   $scope.explorer = {
     search: '',
@@ -56,7 +60,7 @@ module.exports = function ExplorerCtrl($scope) {
     $scope.control.fsretrieve(path)
       .then(function(result) {
         if (result.body) {
-          location.href = result.body.href + '?download'
+          window.open(result.body.href + '?download', "_blank")
         }
       })
       .catch(function(err) {

--- a/res/app/control-panes/explorer/explorer-controller.js
+++ b/res/app/control-panes/explorer/explorer-controller.js
@@ -60,7 +60,7 @@ module.exports = function ExplorerCtrl($scope) {
     $scope.control.fsretrieve(path)
       .then(function(result) {
         if (result.body) {
-          window.open(result.body.href + '?download', "_blank")
+          window.open(result.body.href + '?download', '_blank')
         }
       })
       .catch(function(err) {


### PR DESCRIPTION
While getting a file on a controlled device, the connection to minicap service was stopping due to the URL redirection.

Signed-off-by: Denis barbaron <denis.barbaron@orange.com>