### PR TITLE
Fix AAB installation

### DIFF
--- a/lib/util/bundletool.js
+++ b/lib/util/bundletool.js
@@ -82,9 +82,7 @@ module.exports = function(options) {
                   readStream.on('end', function() {
                     zipfile.readEntry()
                   })
-                  var filePath = entry.fileName.split('/')
-                  var fileName = filePath[filePath.length - 1]
-                  var writeStream = fs.createWriteStream(path.join('/tmp/', fileName))
+                  var writeStream = fs.createWriteStream(path.join('/tmp/', entry.fileName))
                   writeStream.on('error', function(err) {
                     reject(err)
                   })
@@ -96,16 +94,10 @@ module.exports = function(options) {
               reject(err)
             })
             zipfile.once('end', function() {
-              fs.renameSync('/tmp/universal.apk', bundlePath)
-              fs.readdirSync('/tmp/', function(err, files) {
-                if (err) {
-                  reject(err)
-                }
-                for (var file of files) {
-                  fs.unlinkSync(path.resolve('/tmp/', file))
-                }
-                fs.unlinkSync(outputPath)
-              })
+              fs.copyFileSync('/tmp/universal.apk', bundlePath)
+              fs.unlinkSync('/tmp/universal.apk')
+              fs.unlinkSync('/tmp/toc.pb')
+              fs.unlinkSync(outputPath)
               log.info('AAB -> APK')
               resolve(bundle)
             })


### PR DESCRIPTION
Fixed #136 AAB installation fails when /tmp is on different mountpoint than storage-temp save directory

Signed-off-by: nghia.viminh <nghia.viminh@gameloft.com>