### PR TITLE
:bug: Fix: Increase PID retrieval timeout for edge-cases

### DIFF
--- a/lib/units/device/plugins/screen/stream.js
+++ b/lib/units/device/plugins/screen/stream.js
@@ -270,7 +270,7 @@ module.exports = syrup.serial()
       return new Promise(function(resolve) {
           this.on('pid', pidListener = resolve)
         }.bind(this)).bind(this)
-        .timeout(2000)
+        .timeout(5000)
         .finally(function() {
           this.removeListener('pid', pidListener)
         })


### PR DESCRIPTION
Some devices (Pixel 4XL) need more time to retrieve PID, in such cases when the retrieval failed - the whole stream is shutting down, therefore, connection with Minicap is lost which leads to constant empty screen on the Web UI.

Here's the problem described: https://github.com/DeviceFarmer/minicap/issues/17#issuecomment-1022889815