### PR TITLE
update android-device-list version to 1.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@devicefarmer/stf-wiki": "^1.0.0",
     "@julusian/jpeg-turbo": "^0.5.4",
     "@slack/client": "^3.5.4",
-    "android-device-list": "^1.2.7",
+    "android-device-list": "^1.2.8",
     "aws-sdk": "^2.4.13",
     "basic-auth": "^1.0.3",
     "bluebird": "^2.10.1",


### PR DESCRIPTION
Update android-device-list version to (1.2.7 -> 1.2.8) for newly released devices.