### PR TITLE
Enable device market name

### DIFF
--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -45,7 +45,8 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
   }
 
   function enhanceDevice(device) {
-    device.enhancedName = device.marketName || device.name || device.model || device.serial || 'Unknown'
+    device.enhancedName = device.marketName || device.name || device.model || device.serial
+      || 'Unknown'
     device.enhancedModel = device.model || 'Unknown'
     device.enhancedImage120 = '/static/app/devices/icon/x120/' + (device.image || '_default.jpg')
     device.enhancedImage24 = '/static/app/devices/icon/x24/' + (device.image || '_default.jpg')

--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -45,7 +45,7 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
   }
 
   function enhanceDevice(device) {
-    device.enhancedName = device.name || device.model || device.serial || 'Unknown'
+    device.enhancedName = device.marketName || device.name || device.model || device.serial || 'Unknown'
     device.enhancedModel = device.model || 'Unknown'
     device.enhancedImage120 = '/static/app/devices/icon/x120/' + (device.image || '_default.jpg')
     device.enhancedImage24 = '/static/app/devices/icon/x24/' + (device.image || '_default.jpg')


### PR DESCRIPTION
In this PR was added possibility to display correct device market name instead of "more technical" model name

An example:
![image](https://user-images.githubusercontent.com/115991959/196708978-385e30c9-7961-4d3d-b2cf-c21a0a6055e9.png)
