### PR TITLE
Fixing the link to get the package swagger-node-runner from ssh to https

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10237,7 +10237,7 @@ swagger-methods@^1.0.0:
 
 "swagger-node-runner@git+https://github.com/fintechx/swagger-node-runner.git#v1.0.0":
   version "1.2.0"
-  resolved "git+ssh://git@github.com/fintechx/swagger-node-runner.git"
+  resolved "git+https://github.com/fintechx/swagger-node-runner.git"
   dependencies:
     async "^1.5.0"
     bagpipes "^0.2.2"


### PR DESCRIPTION
If the user does not have a generated ssh key pair, then getting from github via ssh fails with an error:
```
npm ERR! code 128
npm ERR! An unknown git error occurred
npm ERR! command git --no-replace-objects ls-remote ssh://git@github.com/fintechx/swagger-node-runner.git
npm ERR! Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
npm ERR! git@github.com: Permission denied (publickey).
```