### PR TITLE
Explorer directory fix

### DIFF
--- a/res/app/control-panes/explorer/index.js
+++ b/res/app/control-panes/explorer/index.js
@@ -1,6 +1,6 @@
 require('./explorer.css')
 
-const S_IFMT  = 0o0170000
+const S_IFMT = 0o0170000
 const S_IFDIR = 0o040000
 const S_IFLNK = 0o120000
 
@@ -24,7 +24,13 @@ module.exports = angular.module('stf.explorer', [])
             }
           }
         }
-        res.unshift((mode & S_IFMT) === S_IFDIR ? 'd' : ((mode & S_IFMT) === S_IFLNK ? 'l' : '-'))
+        if ((mode & S_IFMT) === S_IFDIR) {
+          res.unshift('d')
+        } else if ((mode & S_IFMT) === S_IFLNK) {
+          res.unshift('l')
+        } else {
+          res.unshift('-')
+        }
         return res.join('')
       }
     }

--- a/res/app/control-panes/explorer/index.js
+++ b/res/app/control-panes/explorer/index.js
@@ -1,8 +1,8 @@
 require('./explorer.css')
 
-const S_IFMT = 0o0170000
-const S_IFDIR = 0o040000
-const S_IFLNK = 0o120000
+const S_IFMT = 0o0170000 // Bit mask for checking file types
+const S_IFDIR = 0o040000 // Directory type
+const S_IFLNK = 0o120000 // Symlink type
 
 module.exports = angular.module('stf.explorer', [])
   .run(['$templateCache', function($templateCache) {

--- a/res/app/control-panes/explorer/index.js
+++ b/res/app/control-panes/explorer/index.js
@@ -1,5 +1,9 @@
 require('./explorer.css')
 
+const S_IFMT  = 0o0170000
+const S_IFDIR = 0o040000
+const S_IFLNK = 0o120000
+
 module.exports = angular.module('stf.explorer', [])
   .run(['$templateCache', function($templateCache) {
     $templateCache.put('control-panes/explorer/explorer.pug',
@@ -20,7 +24,7 @@ module.exports = angular.module('stf.explorer', [])
             }
           }
         }
-        res.unshift(mode & 040000 ? 'd' : '-')
+        res.unshift((mode & S_IFMT) === S_IFDIR ? 'd' : ((mode & S_IFMT) === S_IFLNK ? 'l' : '-'))
         return res.join('')
       }
     }
@@ -30,8 +34,7 @@ module.exports = angular.module('stf.explorer', [])
       var mode = m
       if (mode !== null) {
         mode = parseInt(mode, 10)
-        mode -= (mode & 0777)
-        return (mode === 040000) || (mode === 0120000)
+        return ((mode & S_IFMT) === S_IFDIR) || ((mode & S_IFMT) === S_IFLNK)
       }
     }
   })


### PR DESCRIPTION
Noticed on my Samsung Galaxy device some directories were not being recognized as directories in the explorer.  They have different modes, such as 17913 so they aren't equal to 0o40000 even after subtracting the 0o777 to remove the perms.  Looked around and found the header file containing the macros used by commands such as stat: [stat.h](https://github.com/torvalds/linux/blob/master/include/uapi/linux/stat.h#L9-L27).

Just updated the logic of `isDir` to use the bit mask like stat does to capture directories with other flags set.  Also updated the `formatPermissionMode` in the same way and added `l` for symlinks