### PR TITLE
SAML 2.0 unit depends on RethinkDB

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -323,6 +323,7 @@ ExecStartPre=-/usr/bin/docker kill %p-%i
 ExecStartPre=-/usr/bin/docker rm %p-%i
 ExecStart=/usr/bin/docker run --rm \
   --name %p-%i \
+  --link rethinkdb-proxy-28015:rethinkdb \
   -v /srv/ssl/id_provider.cert:/etc/id_provider.cert:ro \
   -e "SECRET=YOUR_SESSION_SECRET_HERE" \
   -e "SAML_ID_PROVIDER_ENTRY_POINT_URL=YOUR_ID_PROVIDER_ENTRY_POINT" \


### PR DESCRIPTION
SAML 2.0 unit depends on RethinkDB now, see https://github.com/DeviceFarmer/stf/blob/2341f49071a516707fb2fb7d4aa3500e2a917f3a/lib/units/auth/saml2.js#L25