### PR TITLE
Add Dockerfile for arm64

### DIFF
--- a/Dockerfile-debian-arm64
+++ b/Dockerfile-debian-arm64
@@ -1,0 +1,67 @@
+#
+# Copyright © 2020,2022 code initially contributed by Orange SA, authors: Denis Barbaron - Licensed under the Apache license 2.0
+#
+
+FROM arm64v8/debian:buster-slim
+
+LABEL Maintainer="Denis Barbaron <denis.barbaron@orange.com>"
+LABEL Name="STF"
+LABEL Url="https://github.com/devicefarmer/stf/"
+LABEL Description="STF docker image for armhf architecture"
+
+# Sneak the stf executable into $PATH.
+ENV PATH /app/bin:$PATH
+
+# Work in app dir by default.
+WORKDIR /app
+
+# Copy app source.
+COPY . /tmp/build/
+
+# Install app requirement
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    echo '--- Updating repositories' && \
+    apt-get update && \
+    echo '--- Building node' && \
+    apt-get -y install wget python3 build-essential cmake && \
+    cd /tmp && \
+    wget --progress=dot:mega \
+      https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-arm64.tar.xz && \
+    tar -xJf node-v*.tar.xz --strip-components 1 -C /usr/local && \
+    rm node-v*.tar.xz && \
+    useradd --system \
+      --create-home \
+      --shell /usr/sbin/nologin \
+      stf && \
+    su stf -s /bin/bash -c '/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js install' && \
+    apt-get -y install --no-install-recommends libzmq3-dev libprotobuf-dev git graphicsmagick yasm && \
+    echo '--- Building app' && \
+    mkdir -p /app && \
+    chown -R stf:stf /tmp/build && \
+    set -x && \
+    cd /tmp/build && \
+    export PATH=$PWD/node_modules/.bin:$PATH && \
+    sed -i'' -e '/phantomjs/d' package.json && \
+    echo 'npm install --python="/usr/bin/python3" --no-optional --loglevel http' | su stf -s /bin/bash && \
+    echo '--- Assembling app' && \
+    echo 'npm pack' | su stf -s /bin/bash && \
+    tar xzf devicefarmer-stf-*.tgz --strip-components 1 -C /app && \
+    echo '/tmp/build/node_modules/.bin/bower cache clean' | su stf -s /bin/bash && \
+    echo 'npm prune --production' | su stf -s /bin/bash && \
+    mv node_modules /app && \
+    chown -R root:root /app && \
+    echo '--- Cleaning up' && \
+    echo 'npm cache clean --force' | su stf -s /bin/bash && \
+    rm -rf ~/.node-gyp && \
+    apt-get -y purge wget python3 build-essential && \
+    apt-get -y clean && \
+    apt-get -y autoremove && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
+    cd /app && \
+    rm -rf /tmp/*
+
+# Switch to the app user.
+USER stf
+
+# Show help by default.
+CMD stf --help


### PR DESCRIPTION
Image can be built on a normal x86_64 linux PC with installed qemu-aarch64-static and properly configured binfmt_misc by running

	docker build --platform linux/arm64/v8 -f Dockerfile-debian-arm64 -t stf .

or

	buildah bud --platform linux/arm64/v8 -f Dockerfile-debian-arm64 -t stf .