### PR TITLE
Add more CLI options for `stf local` to support reverse proxies

### DIFF
--- a/lib/cli/local/index.js
+++ b/lib/cli/local/index.js
@@ -40,6 +40,10 @@ module.exports.builder = function(yargs) {
     , type: 'number'
     , default: 7105
     })
+    .option('app-url', {
+      describe: 'Publicly accessible URL to the app unit.'
+    , type: 'string'
+    })
     .option('auth-options', {
       describe: 'JSON array of options to pass to the auth unit.'
     , type: 'string'
@@ -166,6 +170,11 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: true
     })
+    .option('screen-ws-url-pattern', {
+      describe: 'Publicly accessible URL pattern to use for the screen WebSocket.'
+    , type: 'string'
+    , default: 'ws://${publicIp}:${publicPort}'
+    })
     .option('serial', {
       describe: 'Only use devices with these serial numbers.'
     , type: 'array'
@@ -212,6 +221,10 @@ module.exports.builder = function(yargs) {
       describe: 'The port the websocket unit should run at.'
     , type: 'number'
     , default: 7110
+    })
+    .option('websocket-url', {
+      describe: 'Publicly accessible URL to the websocket unit.'
+    , type: 'string'
     })
     .epilog('Each option can be be overwritten with an environment variable ' +
       'by converting the option to uppercase, replacing dashes with ' +
@@ -288,6 +301,7 @@ module.exports.handler = function(argv) {
         , '--adb-port', argv.adbPort
         , '--vnc-initial-size', argv.vncInitialSize.join('x')
         , '--mute-master', argv.muteMaster
+        , '--screen-ws-url-pattern', argv.screenWsUrlPattern
         ]
         .concat(argv.allowRemote ? ['--allow-remote'] : [])
         .concat(argv.lockRotation ? ['--lock-rotation'] : [])
@@ -300,7 +314,7 @@ module.exports.handler = function(argv) {
           util.format('auth-%s', argv.authType)
         , '--port', argv.authPort
         , '--secret', argv.authSecret
-        , '--app-url', util.format(
+        , '--app-url', argv.appUrl || util.format(
             'http://%s:%d/'
           , argv.publicIp
           , argv.port
@@ -321,7 +335,7 @@ module.exports.handler = function(argv) {
           , saml2: 'saml'
           }[argv.authType] || argv.authType
           )
-        , '--websocket-url', util.format(
+        , '--websocket-url', argv.websocketUrl || util.format(
             'http://%s:%d/'
           , argv.publicIp
           , argv.websocketPort


### PR DESCRIPTION
I use `stf` for a very small installation with just one user and few devices. `stf local` provides enough functionality and is easy to run: just one command without the need to configure all internal services separately. The only missing feature is the ability to provide access securely over the internet.

I want to use nginx reverse proxy with https and client certificate authorization, but currently this does not play well with modern browsers as they refuse to connect to insecure ws:// from secure https:// context.

This patch just adds the ability to configure various URL patterns to match the externally accessible address of the installation.