### PR TITLE
Fix mobile browser detection so that "Desktop mode" works as expected

### DIFF
--- a/res/app/components/stf/browser-info/browser-info-service.js
+++ b/res/app/components/stf/browser-info/browser-info-service.js
@@ -31,10 +31,6 @@ module.exports = function BrowserInfoServiceFactory() {
     return windowWidth < 800
   })
 
-  addTest('mobile', function() {
-    return !!(service.small && service.touch)
-  })
-
   addTest('os', function() {
     var ua = navigator.userAgent
     if (ua.match(/Android/i)) {
@@ -46,6 +42,10 @@ module.exports = function BrowserInfoServiceFactory() {
     else {
       return 'pc'
     }
+  })
+
+  addTest('mobile', function() {
+    return !!(service.small && service.touch && (service.os !== 'pc'))
   })
 
   addTest('webgl', function() {


### PR DESCRIPTION
Currently, enabling the "Desktop site" mode in Chrome on Android does nothing to the stf interface.