### PR TITLE
fix bug on cookie using https

### DIFF
--- a/lib/units/app/index.js
+++ b/lib/units/app/index.js
@@ -72,6 +72,7 @@ module.exports = function(options) {
   app.use(cookieSession({
     name: options.ssid
   , keys: [options.secret]
+  , httpOnly: false
   }))
 
   app.use(auth({


### PR DESCRIPTION
When using STF in HTTPS mode, cookies marked "httpOnly" cannot be deleted by the client-side STF web application, resulting in incorrect session closure at logout stage, this PR allows so this delete NOW.