### PR TITLE
UI support to cleanup bluetooth bonded devices

### DIFF
--- a/lib/units/device/plugins/bluetooth.js
+++ b/lib/units/device/plugins/bluetooth.js
@@ -51,4 +51,24 @@ module.exports = syrup.serial()
           ])
         })
     })
+
+    router.on(wire.BluetoothCleanBondedMessage, function(channel) {
+      var reply = wireutil.reply(options.serial)
+      log.info('Clean bonded Bluetooth devices')
+      service.cleanupBondedBluetoothDevices()
+        .timeout(30000)
+        .then(function() {
+          push.send([
+            channel
+            , reply.okay()
+          ])
+        })
+        .catch(function(err) {
+          log.error('Cleaning Bluetooth bonded devices failed', err.stack)
+          push.send([
+            channel
+            , reply.fail(err.message)
+          ])
+        })
+    })
   })

--- a/lib/units/device/plugins/service.js
+++ b/lib/units/device/plugins/service.js
@@ -612,6 +612,21 @@ module.exports = syrup.serial()
       })
     }
 
+    plugin.cleanupBondedBluetoothDevices = function() {
+      return runServiceCommand(
+        apk.wire.MessageType.DO_CLEAN_BLUETOOTH_BONDED_DEVICES
+        , new apk.wire.DoCleanBluetoothBondedDevicesRequest()
+      )
+        .timeout(15000)
+        .then(function(data) {
+          var response = apk.wire.DoCleanBluetoothBondedDevicesResponse.decode(data)
+          if (response.success) {
+            return true
+          }
+          throw new Error('Unable to clean bluetooth bonded devices')
+        })
+    }
+
     plugin.setRingerMode = function(mode) {
       return runServiceCommand(
           apk.wire.MessageType.SET_RINGER_MODE

--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -786,6 +786,16 @@ module.exports = function(options) {
             )
           ])
         })
+        .on('bluetooth.cleanBonds', function(channel, responseChannel) {
+          joinChannel(responseChannel)
+          push.send([
+            channel
+            , wireutil.transaction(
+              responseChannel
+              , new wire.BluetoothCleanBondedMessage()
+            )
+          ])
+        })
         .on('group.invite', function(channel, responseChannel, data) {
           joinChannel(responseChannel)
           push.send([

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -84,6 +84,7 @@ enum MessageType {
   ConnectStoppedMessage      = 93;
   BluetoothSetEnabledMessage = 94;
   BluetoothGetStatusMessage  = 95;
+  BluetoothCleanBondedMessage = 96;
   GroupUserChangeMessage     = 1200;
   DeviceGroupChangeMessage   = 1201;
   DeviceOriginGroupMessage   = 1202;
@@ -719,6 +720,9 @@ message BluetoothSetEnabledMessage {
 
 message BluetoothGetStatusMessage {
 }
+message BluetoothCleanBondedMessage {
+}
+
 
 // Events, these must be kept in sync with STFService/wire.proto
 

--- a/res/app/components/stf/control/control-service.js
+++ b/res/app/components/stf/control/control-service.js
@@ -303,6 +303,10 @@ module.exports = function ControlServiceFactory(
       return sendTwoWay('bluetooth.get')
     }
 
+    this.cleanBluetoothBondedDevices = function() {
+      return sendTwoWay('bluetooth.cleanBonds')
+    }
+
     window.cc = this
   }
 

--- a/res/app/control-panes/automation/device-settings/device-settings-controller.js
+++ b/res/app/control-panes/automation/device-settings/device-settings-controller.js
@@ -50,6 +50,12 @@ module.exports = function DeviceSettingsCtrl($scope, $timeout) {
     }
   }
 
+  $scope.cleanBluetoothBondedDevices = function() {
+    if ($scope.control) {
+      $scope.control.cleanBluetoothBondedDevices()
+    }
+  }
+
   $scope.$watch('ringerMode', function(newValue, oldValue) {
     if (oldValue) {
       if ($scope.control) {

--- a/res/app/control-panes/automation/device-settings/device-settings.pug
+++ b/res/app/control-panes/automation/device-settings/device-settings.pug
@@ -29,6 +29,8 @@
             i.fa.fa-power-off.fa-fw
           label.btn.btn-sm.btn-primary-outline(ng-model='bluetoothEnabled', ng-click='toggleBluetooth(true)', ng-disabled='bluetoothPending', uib-btn-radio='true', uib-tooltip='{{"Enable Bluetooth" | translate}}')
             i.fa.fa-bluetooth-b.fa-fw
+          label.btn.btn-sm.btn-primary-outline(ng-click='cleanBluetoothBondedDevices()', uib-tooltip='{{"Clean Bluetooth bonded devices" | translate}}')
+            i.fa.fa-trash.fa-fw
 
     //.row
       .col-md-12


### PR DESCRIPTION
UI button to clean paired (bonded) bluetooth devices.
Based on https://github.com/DeviceFarmer/STFService.apk/pull/128 which is updated here in #755 .

![ble_bond_clean](https://github.com/DeviceFarmer/stf/assets/3822425/e776d85a-44db-489d-9ae1-f76c683df033)
