### PR TITLE
options to disable bluetooth and/or clean bonded (paired) devices

### DIFF
--- a/lib/cli/device/index.js
+++ b/lib/cli/device/index.js
@@ -29,6 +29,16 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: true
     })
+    .option('cleanup-disable-bluetooth', {
+      describe: 'Whether to disable Bluetooth during cleanup.'
+    , type: 'boolean'
+    , default: false
+    })
+    .option('cleanup-bluetooth-bonds', {
+      describe: 'Whether to remove Bluetooth bonds during cleanup.'
+    , type: 'boolean'
+    , default: false
+    })
     .option('connect-port', {
       describe: 'Port allocated to adb connections.'
     , type: 'number'
@@ -189,6 +199,8 @@ module.exports.handler = function(argv) {
   , muteMaster: argv.muteMaster
   , lockRotation: argv.lockRotation
   , cleanup: argv.cleanup
+  , cleanupDisableBluetooth: argv.cleanupDisableBluetooth
+  , cleanupBluetoothBonds: argv.cleanupBluetoothBonds
   , screenReset: argv.screenReset
   })
 }

--- a/lib/cli/local/index.js
+++ b/lib/cli/local/index.js
@@ -109,6 +109,16 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: true
     })
+    .option('cleanup-disable-bluetooth', {
+      describe: 'Whether to disable Bluetooth during cleanup.'
+    , type: 'boolean'
+    , default: false
+    })
+    .option('cleanup-bluetooth-bonds', {
+      describe: 'Whether to remove Bluetooth bonds during cleanup.'
+    , type: 'boolean'
+    , default: false
+    })
     .option('group-timeout', {
       alias: 't'
     , describe: 'Timeout in seconds for automatic release of inactive devices.'
@@ -306,6 +316,8 @@ module.exports.handler = function(argv) {
         .concat(argv.allowRemote ? ['--allow-remote'] : [])
         .concat(argv.lockRotation ? ['--lock-rotation'] : [])
         .concat(!argv.cleanup ? ['--no-cleanup'] : [])
+        .concat(argv.cleanupDisableBluetooth ? ['--cleanup-disable-bluetooth'] : [])
+        .concat(argv.cleanupBluetoothBonds ? ['--cleanup-bluetooth-bonds'] : [])
         .concat(!argv.screenReset ? ['--no-screen-reset'] : [])
         .concat(argv.serial))
 

--- a/lib/cli/provider/index.js
+++ b/lib/cli/provider/index.js
@@ -43,6 +43,16 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: true
     })
+    .option('cleanup-disable-bluetooth', {
+      describe: 'Whether to disable Bluetooth during cleanup.'
+    , type: 'boolean'
+    , default: false
+    })
+    .option('cleanup-bluetooth-bonds', {
+      describe: 'Whether to remove Bluetooth bonds during cleanup.'
+    , type: 'boolean'
+    , default: false
+    })
     .option('connect-push', {
       alias: 'p'
     , describe: 'Device-side ZeroMQ PULL endpoint to connect to.'
@@ -223,6 +233,8 @@ module.exports.handler = function(argv) {
       }, []))
       .concat(argv.lockRotation ? ['--lock-rotation'] : [])
       .concat(!argv.cleanup ? ['--no-cleanup'] : [])
+      .concat(argv.cleanupDisableBluetooth ? ['--cleanup-disable-bluetooth'] : [])
+      .concat(argv.cleanupBluetoothBonds ? ['--cleanup-bluetooth-bonds'] : [])
       .concat(!argv.screenReset ? ['--no-screen-reset'] : [])
 
       return fork(cli, args)

--- a/lib/units/device/plugins/cleanup.js
+++ b/lib/units/device/plugins/cleanup.js
@@ -8,7 +8,8 @@ module.exports = syrup.serial()
   .dependency(require('../support/adb'))
   .dependency(require('../resources/service'))
   .dependency(require('./group'))
-  .define(function(options, adb, service, group) {
+  .dependency(require('./service'))
+  .define(function(options, adb, stfservice, group, service) {
     var log = logger.createLogger('device:plugins:cleanup')
     var plugin = Object.create(null)
 
@@ -31,7 +32,7 @@ module.exports = syrup.serial()
 
     return listPackages()
       .then(function(initialPackages) {
-        initialPackages.push(service.pkg)
+        initialPackages.push(stfservice.pkg)
 
         plugin.removePackages = function() {
           return listPackages()
@@ -40,9 +41,31 @@ module.exports = syrup.serial()
               return Promise.map(remove, uninstallPackage)
             })
         }
+        plugin.disableBluetooth = function() {
+          if (!options.cleanupDisableBluetooth) {
+            return
+          }
+          return service.getBluetoothStatus()
+            .then(function(enabled) {
+              if (enabled) {
+                log.info('Disabling Bluetooth')
+                return service.setBluetoothEnabled(false)
+              }
+            })
+        }
+        plugin.cleanBluetoothBonds = function() {
+          if (!options.cleanupBluetoothBonds) {
+            return
+          }
+          log.info('Cleanup Bluetooth bonds')
+          return service.cleanBluetoothBonds()
+        }
 
         group.on('leave', function() {
-          plugin.removePackages()
+          Promise.all([
+            plugin.removePackages()
+          , plugin.cleanBluetoothBonds()
+          , plugin.disableBluetooth()])
         })
       })
       .return(plugin)

--- a/lib/units/device/plugins/service.js
+++ b/lib/units/device/plugins/service.js
@@ -704,6 +704,20 @@ module.exports = syrup.serial()
         })
     }
 
+    plugin.cleanBluetoothBonds = function() {
+      return runServiceCommand(
+        apk.wire.MessageType.DO_CLEAN_BLUETOOTH_BONDED_DEVICES
+        , new apk.wire.DoCleanBluetoothBondedDevicesRequest()
+      )
+        .timeout(10000)
+        .then(function(data) {
+          var response = apk.wire.DoCleanBluetoothBondedDevicesResponse.decode(data)
+          if (!response.success) {
+            throw new Error('Unable to clean Bluetooth bonded devices')
+          }
+        })
+    }
+
     plugin.getBluetoothStatus = function() {
       return runServiceCommand(
         apk.wire.MessageType.GET_BLUETOOTH_STATUS


### PR DESCRIPTION
Two new CLI arguments for cleanup phase;

```shell
  --cleanup-disable-bluetooth  Whether to disable Bluetooth during cleanup. [boolean] [default: false]
  --cleanup-bluetooth-bonds    Whether to remove Bluetooth bonds during cleanup.  [boolean] [default: false]
```

This allows to ensure that phone are not bonded to devices after it's released.