### PR TITLE
grant STFService permissions to be able to use features

### DIFF
--- a/lib/units/device/resources/service.js
+++ b/lib/units/device/resources/service.js
@@ -8,6 +8,7 @@ var pathutil = require('../../../util/pathutil')
 var streamutil = require('../../../util/streamutil')
 var promiseutil = require('../../../util/promiseutil')
 var logger = require('../../../util/logger')
+const adbkit = require('@devicefarmer/adbkit')
 
 module.exports = syrup.serial()
   .dependency(require('../support/adb'))
@@ -96,7 +97,19 @@ module.exports = syrup.serial()
         })
     }
 
+    function setPermission(path) {
+      return adb.shell(options.serial, [
+        'pm', 'grant', resource.pkg
+        , 'android.permission.BLUETOOTH_CONNECT'
+        , 'android.permission.SYSTEM_ALERT_WINDOW'])
+        .then(adbkit.util.readAll)
+        .then(function(out) {
+          log.debug('output of granting permissions to STFService: ' + out.toString())
+          return path
+        })
+    }
     return install()
+      .then(setPermission)
       .then(function(path) {
         log.info('STFService up to date')
         resource.path = path


### PR DESCRIPTION
add required permissions for new sdk:s to be able to use "find me" and bluetooth features.

tested with android14 and old android 9 phone.