### PR TITLE
option to cleanup tmp folder during cleanup phase

### DIFF
--- a/lib/cli/device/index.js
+++ b/lib/cli/device/index.js
@@ -39,6 +39,11 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: false
     })
+    .option('cleanup-folder', {
+      describe: 'Whether to remove pre-defined folder during cleanup. eg. "--cleanup-folder /data/local --cleanup-folder /tmp"'
+    , type: 'array'
+    , default: []
+    })
     .option('connect-port', {
       describe: 'Port allocated to adb connections.'
     , type: 'number'
@@ -201,6 +206,7 @@ module.exports.handler = function(argv) {
   , cleanup: argv.cleanup
   , cleanupDisableBluetooth: argv.cleanupDisableBluetooth
   , cleanupBluetoothBonds: argv.cleanupBluetoothBonds
+  , cleanupFolder: argv.cleanupFolder
   , screenReset: argv.screenReset
   })
 }

--- a/lib/cli/device/index.js
+++ b/lib/cli/device/index.js
@@ -40,7 +40,8 @@ module.exports.builder = function(yargs) {
     , default: false
     })
     .option('cleanup-folder', {
-      describe: 'Whether to remove pre-defined folder during cleanup. eg. "--cleanup-folder /data/local --cleanup-folder /tmp"'
+      describe: 'Whether to remove pre-defined folder during cleanup. ' +
+        'eg. "--cleanup-folder /data/local /tmp"'
     , type: 'array'
     , default: []
     })

--- a/lib/cli/local/index.js
+++ b/lib/cli/local/index.js
@@ -120,7 +120,8 @@ module.exports.builder = function(yargs) {
     , default: false
     })
     .option('cleanup-folder', {
-      describe: 'Whether to remove pre-defined folder during cleanup. eg. "--cleanup-folder /data/local --cleanup-folder /tmp"'
+      describe: 'Whether to remove pre-defined folder during cleanup. ' +
+        'eg. "--cleanup-folder /data/local /tmp"'
     , type: 'array'
     , default: []
     })

--- a/lib/cli/local/index.js
+++ b/lib/cli/local/index.js
@@ -119,6 +119,11 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: false
     })
+    .option('cleanup-folder', {
+      describe: 'Whether to remove pre-defined folder during cleanup. eg. "--cleanup-folder /data/local --cleanup-folder /tmp"'
+    , type: 'array'
+    , default: []
+    })
     .option('group-timeout', {
       alias: 't'
     , describe: 'Timeout in seconds for automatic release of inactive devices.'
@@ -318,6 +323,7 @@ module.exports.handler = function(argv) {
         .concat(!argv.cleanup ? ['--no-cleanup'] : [])
         .concat(argv.cleanupDisableBluetooth ? ['--cleanup-disable-bluetooth'] : [])
         .concat(argv.cleanupBluetoothBonds ? ['--cleanup-bluetooth-bonds'] : [])
+        .concat(argv.cleanupFolder ? ['--cleanup-folder'].concat(argv.cleanupFolder) : [])
         .concat(!argv.screenReset ? ['--no-screen-reset'] : [])
         .concat(argv.serial))
 

--- a/lib/cli/provider/index.js
+++ b/lib/cli/provider/index.js
@@ -53,6 +53,11 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: false
     })
+    .option('cleanup-folder', {
+      describe: 'Whether to remove pre-defined folder during cleanup. eg. "--cleanup-folder /data/local --cleanup-folder /tmp"'
+    , type: 'array'
+    , default: []
+    })
     .option('connect-push', {
       alias: 'p'
     , describe: 'Device-side ZeroMQ PULL endpoint to connect to.'
@@ -235,6 +240,7 @@ module.exports.handler = function(argv) {
       .concat(!argv.cleanup ? ['--no-cleanup'] : [])
       .concat(argv.cleanupDisableBluetooth ? ['--cleanup-disable-bluetooth'] : [])
       .concat(argv.cleanupBluetoothBonds ? ['--cleanup-bluetooth-bonds'] : [])
+      .concat(argv.cleanupFolder ? ['--cleanup-folder'].concat(argv.cleanupFolder) : [])
       .concat(!argv.screenReset ? ['--no-screen-reset'] : [])
 
       return fork(cli, args)

--- a/lib/cli/provider/index.js
+++ b/lib/cli/provider/index.js
@@ -54,7 +54,8 @@ module.exports.builder = function(yargs) {
     , default: false
     })
     .option('cleanup-folder', {
-      describe: 'Whether to remove pre-defined folder during cleanup. eg. "--cleanup-folder /data/local --cleanup-folder /tmp"'
+      describe: 'Whether to remove pre-defined folder during cleanup. ' +
+        'eg. "--cleanup-folder /data/local /tmp"'
     , type: 'array'
     , default: []
     })

--- a/lib/units/device/plugins/cleanup.js
+++ b/lib/units/device/plugins/cleanup.js
@@ -139,16 +139,21 @@ module.exports = syrup.serial()
         }
 
         plugin.cleanFolders = function() {
-          return Promise.all(options.cleanupFolder.map(cleanFolder))
+          return Promise.each(options.cleanupFolder, cleanFolder)
         }
 
         group.on('leave', function() {
-          Promise.all([
-            plugin.removePackages()
-          , plugin.cleanBluetoothBonds()
-          , plugin.disableBluetooth()
-          , plugin.cleanFolders()
-          ])
+          Promise.each([
+              plugin.removePackages
+            , plugin.cleanBluetoothBonds
+            , plugin.disableBluetooth
+            , plugin.cleanFolders
+            , function() {
+              log.debug('Cleanup done')
+            }
+          ], function(fn) {
+            return fn()
+          })
         })
       })
       .return(plugin)

--- a/lib/units/device/plugins/cleanup.js
+++ b/lib/units/device/plugins/cleanup.js
@@ -3,6 +3,8 @@ var Promise = require('bluebird')
 var _ = require('lodash')
 
 var logger = require('../../../util/logger')
+const util = require('util')
+const adbkit = require('@devicefarmer/adbkit')
 
 module.exports = syrup.serial()
   .dependency(require('../support/adb'))
@@ -12,10 +14,31 @@ module.exports = syrup.serial()
   .define(function(options, adb, stfservice, group, service) {
     var log = logger.createLogger('device:plugins:cleanup')
     var plugin = Object.create(null)
-
     if (!options.cleanup) {
       return plugin
     }
+
+    // ignore system folders. This is to prevent accidental deletion of system files.
+    // It's admin's responsibility to set correct cleanup folders.
+    var systemFolders = [
+        '/system'
+      , '/boot'
+      , '/proc'
+      , '/vendor'
+      , '/dev'
+      , '/sys'
+    ]
+    // if folder starts with system folder, throw an error and stop provider.
+    // this is to prevent accidental deletion of system files.
+    options.cleanupFolder.forEach(function(folder) {
+      if (systemFolders.some(function(systemFolder) {
+        return folder.startsWith(systemFolder)
+      })) {
+        log.warn('Warning, Tried to clean system folder. Ignoring: %s', folder)
+        throw new Error(util.format('Cleanup %s is not allowed!', folder))
+      }
+    })
+    log.debug('Cleanup folders: %j', options.cleanupFolder)
 
     function listPackages() {
       return adb.getPackages(options.serial)
@@ -27,6 +50,60 @@ module.exports = syrup.serial()
         .catch(function(err) {
           log.warn('Unable to clean up package "%s"', pkg, err)
           return true
+        })
+    }
+    function removeFile(filename) {
+      return adb
+        // get file size
+        .shell(options.serial, util.format('du -h "%s"', filename))
+        .then(adbkit.util.readAll)
+        .then(function(output) {
+          // output is in format: size filename. extract size;
+          var size = output.toString().split('\t')[0]
+          log.info('Removing %s (%s)', filename, size)
+          return adb
+            .shell(options.serial, util.format('rm -rf "%s"', filename))
+            .then(adbkit.util.readAll)
+        })
+        .catch(function(err) {
+          log.warn(util.format('Unable to clean %s folder', filename), err)
+        })
+    }
+    function listFiles(folder, ignoreFiles = []) {
+       return adb.readdir(options.serial, folder)
+            .then(function(files) {
+              // drop . and .. from list
+              return files.filter(function(file) {
+                return file.name !== '.' && file.name !== '..'
+              })
+            })
+            .then(function(files) {
+              return files.map(function(file){
+                return util.format('%s/%s', folder, file.name)
+              })
+            })
+           .then(function(files) {
+              return files.filter(function(file) {
+                return !ignoreFiles.includes(file)
+              })
+           })
+    }
+    function cleanFolder(folder) {
+      log.info('Cleanup %s folder', folder)
+      // ignore STF service files
+      var ignoreServiceFiles = [
+          '/data/local/tmp/minicap.apk'
+        , '/data/local/tmp/minicap'
+        , '/data/local/tmp/minicap.so'
+        , '/data/local/tmp/minitouch'
+        , '/data/local/tmp/minirev'
+      ]
+      return listFiles(folder, ignoreServiceFiles)
+        .then(function(files) {
+          return Promise.map(files, removeFile)
+        })
+        .catch(function(err) {
+          log.warn('Unable to clean %s folder', folder, err)
         })
     }
 
@@ -61,11 +138,17 @@ module.exports = syrup.serial()
           return service.cleanBluetoothBonds()
         }
 
+        plugin.cleanFolders = function() {
+          return Promise.all(options.cleanupFolder.map(cleanFolder))
+        }
+
         group.on('leave', function() {
           Promise.all([
             plugin.removePackages()
           , plugin.cleanBluetoothBonds()
-          , plugin.disableBluetooth()])
+          , plugin.disableBluetooth()
+          , plugin.cleanFolders()
+          ])
         })
       })
       .return(plugin)

--- a/lib/units/device/plugins/cleanup.js
+++ b/lib/units/device/plugins/cleanup.js
@@ -78,7 +78,7 @@ module.exports = syrup.serial()
               })
             })
             .then(function(files) {
-              return files.map(function(file){
+              return files.map(function(file) {
                 return util.format('%s/%s', folder, file.name)
               })
             })


### PR DESCRIPTION
To keep phones stable for longer duration, e.g. `/data/local/tmp` folder seem to be needed to cleanup every now and then. This was earlier done in separate apk/tool, but simpler to do it directly by `stf`, so bring such functionality natively here. If folder/file removing fails, error message are written to logs.  Cleanup ignore `stf` service files ( `minicap.apk, minicap, minicap.so, minitouch, minirev`).

NOTE: "fool detection" is very simple and it's easy to round up if user really want to make harm for phone. Feature is still deployment configuration so it's admin who can mess up devices, who normally won't do such thing, so I think it's okay. Currently provider raises at startup phase if one of following path are part of given cleanup-folder prefix; `/system, /boot, /proc, /vendor, /dev, /sys`


```shell
--cleanup-folder             Whether to remove pre-defined folder during
                               cleanup. eg. "--cleanup-folder /data/local /tmp"      [array] [default: []]
```

Logs e.g.:
```shell
> stf local "--cleanup-folder" "/tmp/A" "/tmp/C"
...
2024-08-16T10:38:11.591Z DBG/device:plugins:cleanup 47913 [39261JEHN08067] Cleanup folders: ["/tmp/A","/tmp/C"]
...
2024-08-16T11:01:46.288Z INF/device:plugins:shell 49299 [39261JEHN08067] Running shell command "touch /tmp/A/asd"
2024-08-16T11:01:49.083Z INF/device:plugins:shell 49299 [39261JEHN08067] Running shell command "touch /tmp/C/qwe"
...
2024-08-16T11:01:50.962Z INF/device:plugins:cleanup 49299 [39261JEHN08067] Cleanup /tmp/A folder
2024-08-16T11:01:51.005Z INF/device:plugins:cleanup 49299 [39261JEHN08067] Removing /tmp/A/asd (0)
2024-08-16T11:01:51.053Z INF/device:plugins:cleanup 49299 [39261JEHN08067] Cleanup /tmp/C folder
2024-08-16T11:01:51.119Z INF/device:plugins:cleanup 49299 [39261JEHN08067] Removing /tmp/C/qwe (0)
2024-08-16T11:01:51.166Z DBG/device:plugins:cleanup 49299 [39261JEHN08067] Cleanup done

```


This also reduce parallel adb commands usage - run them one by one -  to ensure them all are successfully executed.