### PR TITLE
Prevent crash when running `stf local` from an alternate package manager like yarn, pnpm, or when using nvm

### DIFF
--- a/lib/util/pathutil.js
+++ b/lib/util/pathutil.js
@@ -19,20 +19,23 @@ module.exports.vendor = function(target) {
 
 // Export
 module.exports.module = function(target) {
-  // Uses require.resolve to find module paths.
-  // For alternative package managers like yarn, pnpm, .nvm, etc. this is more reliable than looking in node_modules
+  // Uses require.resolve to lookup module relative targets.
+  // For alternative package managers like yarn, pnpm, .nvm, etc. this is more reliable than computing paths in node_modules
 
-  const isScoped = target.startsWith('@')
+  // require.resolve will reject requests for paths that are not modules (i.e not javascript or JSON)
+  // We get around this by first looking up the package.json of the containing package and then
+  // computing the full module path relative to package.json
+
   const parts = target.split('/')
 
-  const isPackageNameOnly = (parts.length === 1) || (isScoped && parts.length === 2)
-  if (isPackageNameOnly) {
-    // Deal with the special case where the target is an NPM package
-    return path.dirname(require.resolve(path.posix.join(target, 'package.json')))
-  }
-  else {
-    return require.resolve(target)
-  }
+  const packageNameLength = target.startsWith('@') ? 2 : 1
+  const packageName = parts.slice(0, packageNameLength).join('/')
+  const moduleName = parts.slice(packageNameLength).join('/')
+
+  const packageJSONPath = require.resolve(path.posix.join(packageName, 'package.json'))
+  const result = path.join(packageJSONPath, '..', moduleName)
+
+  return result
 }
 
 // Export

--- a/lib/util/pathutil.js
+++ b/lib/util/pathutil.js
@@ -19,7 +19,20 @@ module.exports.vendor = function(target) {
 
 // Export
 module.exports.module = function(target) {
-  return path.resolve(__dirname, '../../node_modules', target)
+  // Uses require.resolve to find module paths.
+  // For alternative package managers like yarn, pnpm, .nvm, etc. this is more reliable than looking in node_modules
+
+  const isScoped = target.startsWith('@')
+  const parts = target.split('/')
+
+  const isPackageNameOnly = (parts.length === 1) || (isScoped && parts.length === 2)
+  if (isPackageNameOnly) {
+    // Deal with the special case where the target is an NPM package
+    return path.dirname(require.resolve(path.posix.join(target, 'package.json')))
+  }
+  else {
+    return require.resolve(target)
+  }
 }
 
 // Export


### PR DESCRIPTION
`pathutil.module` directly traverses node_modules but the layout may not be the same with alternate package managers.
`pathutil.module` has been updated to use `require.resolve` instead.

See https://github.com/DeviceFarmer/stf/issues/423