### PR TITLE
fix: remove progressed from call as it prohibits the system from working

### DIFF
--- a/lib/units/device/resources/service.js
+++ b/lib/units/device/resources/service.js
@@ -89,13 +89,6 @@ module.exports = syrup.serial()
                 )
                 .timeout(65000)
             })
-            .progressed(function() {
-              log.warn(
-                'STFService installation is taking a long time; ' +
-                'perhaps you have to accept 3rd party app installation ' +
-                'on the device?'
-              )
-            })
             .then(function() {
               return getPath()
             })


### PR DESCRIPTION
The progressed filter (?) stops DeviceFarmer from working both in a container and a bare-metal environment so this pr removes it.