### PR TITLE
db/api: remove timespamp comparison on deviceState change

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -1227,24 +1227,9 @@ dbapi.unsetDeviceConnectUrl = function(serial) {
 
 dbapi.saveDeviceStatus = function(serial, status, statusTimeStamp) {
   return db.run(r.table('devices').get(serial).update({
-    status:
-      r.branch(
-        r.expr(statusTimeStamp).gt(r.row('statusTimeStamp'))
-      , status
-      , r.row('status')
-      )
-  , statusChangedAt:
-      r.branch(
-        r.expr(statusTimeStamp).gt(r.row('statusTimeStamp'))
-      , r.now()
-      , r.row('statusChangedAt')
-      )
-  , statusTimeStamp:
-      r.branch(
-        r.expr(statusTimeStamp).gt(r.row('statusTimeStamp'))
-      , statusTimeStamp
-      , r.row('statusTimeStamp')
-      )
+    status: status
+  , statusChangedAt: r.now()
+  , statusTimeStamp: statusTimeStamp
   }))
 }
 


### PR DESCRIPTION
Hi, all.

Since upgrading to 3.7.2, we've been having problems with devices not coming online and being shown in 'offline' state, even though provider clearly reports that device is ready and availalbe.

After a lot of tracing and debugging, I've traced it down to the saveDeviceStatus function and it appears that the timestamp checks added in november are preventing latest device state from being saved.

My uneducated guess is that in situations where the clocks of the provider and processor are not in perfect sync, the database can miss state updates if they arrive quickly one after another. 

Since removing the timestamp verification as detailed in this PR, devices get registred flawelessy every single time without fault and device state is always correctly reflected in the UI.

This timestamp check was added recently, i assume there was a good reason for it i'm simply not aware of. 
Would love to hear your thoughts on how to resolve this edgecase.

