### PR TITLE
Log reasons for phone reservation cancellations

### DIFF
--- a/lib/units/device/plugins/group.js
+++ b/lib/units/device/plugins/group.js
@@ -76,7 +76,7 @@ module.exports = syrup.serial()
     plugin.leave = function(reason) {
       return plugin.get()
         .then(function(group) {
-          log.important('No longer owned by "%s"', group.email)
+          log.important('No longer owned by "%s" (reason: %s)', group.email, reason)
           log.info('Unsubscribing from group channel "%s"', group.group)
 
           channels.unregister(group.group)


### PR DESCRIPTION
This PR updates the phone release flow to log the reasons why a reservation is left or canceled, enabling better visibility and debugging of early exits.