### PR TITLE
feat: Display STF version in Web UI

### DIFF
--- a/lib/units/app/index.js
+++ b/lib/units/app/index.js
@@ -16,7 +16,7 @@ var compression = require('compression')
 
 var logger = require('../../util/logger')
 var pathutil = require('../../util/pathutil')
-var packageJson = require('../../package.json')
+var packageJson = require('../../../package.json')
 
 var auth = require('./middleware/auth')
 var deviceIconMiddleware = require('./middleware/device-icons')

--- a/lib/units/app/index.js
+++ b/lib/units/app/index.js
@@ -16,6 +16,7 @@ var compression = require('compression')
 
 var logger = require('../../util/logger')
 var pathutil = require('../../util/pathutil')
+var packageJson = require('../../package.json')
 
 var auth = require('./middleware/auth')
 var deviceIconMiddleware = require('./middleware/device-icons')
@@ -112,6 +113,7 @@ module.exports = function(options) {
           wsUrl.query.uip = req.ip
           return url.format(wsUrl)
         })()
+      , stfVersion: packageJson.version
       }
     , user: req.user
     }

--- a/res/app/app.js
+++ b/res/app/app.js
@@ -35,4 +35,8 @@ require.ensure([], function(require) {
     .config(function(hotkeysProvider) {
       hotkeysProvider.templateTitle = 'Keyboard Shortcuts:'
     })
+    
+    .run(['$rootScope', 'AppState', function($rootScope, AppState) {
+      $rootScope.state = AppState
+    }])
 })

--- a/res/app/menu/menu.css
+++ b/res/app/menu/menu.css
@@ -70,6 +70,17 @@
   min-height: 44px !important;
 }
 
+.stf-menu .version-text {
+  display: inline-block;
+  font-size: 14px;
+  line-height: 44px;
+  color: #777777;
+  font-weight: 400;
+  padding: 0 10px;
+  text-align: center;
+  vertical-align: middle;
+}
+
 .stf-menu .information-level {
   background-color: #5bc0df;
 }

--- a/res/app/menu/menu.pug
+++ b/res/app/menu/menu.pug
@@ -41,7 +41,10 @@
         type='button'
         ng-click='logout()')
           i.fa.fa-sign-out
-          span(translate) Logout 
+          span(translate) Logout
+
+      li
+        span.version-text v{{ $root.state.config.stfVersion }}
 
       li(ng-show='!$root.basicMode')
         a(ng-href='/#!/help', accesskey='6')

--- a/res/test/e2e/menu/menu-spec.js
+++ b/res/test/e2e/menu/menu-spec.js
@@ -1,6 +1,6 @@
 describe('Menu', function() {
   it('should display the STF version', function() {
-    // Navigate to the device list page (default page after login)
+    // Navigate to the device list page
     browser.get('/#!/devices')
 
     // Find the version display element

--- a/res/test/e2e/menu/menu-spec.js
+++ b/res/test/e2e/menu/menu-spec.js
@@ -1,0 +1,16 @@
+describe('Menu', function() {
+  it('should display the STF version', function() {
+    // Navigate to the device list page (default page after login)
+    browser.get('/#!/devices');
+
+    // Find the version display element
+    var versionElement = element(by.css('.stf-menu .version-text'));
+
+    // Assert that the element is present
+    expect(versionElement.isPresent()).toBe(true);
+
+    // Assert that the text matches 'v' + version from package.json
+    // Using a regex to be more flexible with the exact version number.
+    expect(versionElement.getText()).toMatch(/^v\d+\.\d+\.\d+$/);
+  });
+});

--- a/res/test/e2e/menu/menu-spec.js
+++ b/res/test/e2e/menu/menu-spec.js
@@ -1,16 +1,16 @@
 describe('Menu', function() {
   it('should display the STF version', function() {
     // Navigate to the device list page (default page after login)
-    browser.get('/#!/devices');
+    browser.get('/#!/devices')
 
     // Find the version display element
-    var versionElement = element(by.css('.stf-menu .version-text'));
+    var versionElement = element(by.css('.stf-menu .version-text'))
 
     // Assert that the element is present
-    expect(versionElement.isPresent()).toBe(true);
+    expect(versionElement.isPresent()).toBe(true)
 
     // Assert that the text matches 'v' + version from package.json
     // Using a regex to be more flexible with the exact version number.
-    expect(versionElement.getText()).toMatch(/^v\d+\.\d+\.\d+$/);
-  });
-});
+    expect(versionElement.getText()).toMatch(/^v\d+\.\d+\.\d+$/)
+  })
+})


### PR DESCRIPTION
Adds the STF application version to the main menu in the Web UI.
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/495473e0-d576-483e-acdf-2dad1578ff3c" />

Changes:
- Modified `lib/units/app/index.js` to read the version from `package.json` and make it available to the frontend via the `GLOBAL_APPSTATE.config.stfVersion` variable.
- Updated `res/app/menu/menu.pug` to display this version in the top navigation bar, near the help icon. The format is "vX.Y.Z".
- Added an E2E test (`res/test/e2e/menu/menu-spec.js`) to verify the presence and correct format of the version string in the UI.