### PR TITLE
fix response status code of the createUserAccessToken API in swagger file.

### DIFF
--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -1213,7 +1213,7 @@ paths:
           required: true
           type: string
       responses:
-        "200":
+        "201":
           description: Access token information
           schema:
             $ref: "#/definitions/UserAccessTokenResponse"


### PR DESCRIPTION
/users/{email}/accessTokens API returns 201 when successful, not 200.

[lib/units/api/controllers/users.js#L421C10-L421C31](https://github.com/DeviceFarmer/stf/blob/eca8d78b707a3e05d6ad188bde7d5e7209c0d80c/lib/units/api/controllers/users.js#L421C10-L421C31)
[lib/units/api/controllers/user.js#L543](https://github.com/DeviceFarmer/stf/blob/eca8d78b707a3e05d6ad188bde7d5e7209c0d80c/lib/units/api/controllers/user.js#L543)