### PR TITLE
fix: Promise.settle's parameter in stream.js

### DIFF
--- a/lib/units/device/plugins/screen/stream.js
+++ b/lib/units/device/plugins/screen/stream.js
@@ -504,9 +504,9 @@ module.exports = syrup.serial()
         frameProducer.on('readable', function next() {
           var frame = frameProducer.nextFrame()
           if (frame) {
-            Promise.settle([broadcastSet.keys().map(function(id) {
+            Promise.settle(broadcastSet.keys().map(function(id) {
               return broadcastSet.get(id).onFrame(frame)
-            })]).then(next)
+            })).then(next)
           }
           else {
             frameProducer.needFrame()


### PR DESCRIPTION
this fix https://github.com/DeviceFarmer/stf/commit/feb77c4396d4209de48779fa855daa382cc11f28.

`broadcastSet.values().map` will return an array of promises. Before the fix, `Promise.settle` will settle for `[[promise0, promise1, ...]]`, so in fact there is no wait for any of the promises at all; after the fix `Promise.settle` will settle for `[promise0, promise1, ...]`, then the callback will only called after all promises are resolved.