### PR TITLE
fix: recover devices stuck after losing the registration ack

### DIFF
--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -161,6 +161,23 @@ module.exports = function(options) {
 
       // Wait for others to acknowledge the device
       var register = new Promise(function(resolve) {
+        var registerTimeout = 15000
+        var settled = false
+        function settle(viaAck) {
+          if (settled) {
+            return
+          }
+          settled = true
+          if (!viaAck) {
+            log.warn(
+              'Registration ack for "%s" not received in %dms; proceeding anyway'
+            , device.id
+            , registerTimeout
+            )
+          }
+          resolve()
+        }
+
         // Tell others we found a device
         push.send([
           wireutil.global
@@ -175,7 +192,12 @@ module.exports = function(options) {
           ))
         ])
 
-        privateTracker.once('register', resolve)
+        privateTracker.once('register', function() {
+          settle(true)
+        })
+        setTimeout(function() {
+          settle(false)
+        }, registerTimeout)
       })
 
 


### PR DESCRIPTION
## Problem

The `provider` unit gates all per-device handling behind a `register` Promise that only resolves once the device's `DeviceRegisteredMessage` ack is received:

```js
var register = new Promise(function(resolve) {
  // Tell others we found a device
  push.send([ ...DeviceIntroductionMessage... ])
  privateTracker.once('register', resolve)
})
...
register.then(function() {
  log.info('Registered device "%s"', device.id)
  check()
})
```

That ack is sent fire-and-forget over ZeroMQ. If it is ever lost — or fails to resolve **this particular** closure — the Promise never resolves, so `check()` never runs and the device stays stuck `Providing 0 of N; ignoring`, shows offline in the UI, and never recovers without a provider restart.

### How to reproduce

Reboot a device **while it is actively in use** (live screen + an active control session). On the reboot the device worker exits (`Forward shell ended; we shall share its fate`) and adbkit's `trackDevices` re-adds the device, recreating the per-device closure and a fresh `register` Promise. The re-introduction is sent and the device is saved again, but the ack does not resolve the recreated closure, so the device wedges permanently at `Providing 0 of 1; ignoring`.

## Fix

Resolve `register` after a timeout if the ack has not arrived, so `check()` runs and the device recovers:

```js
var register = new Promise(function(resolve) {
  var registerTimeout = 15000
  var settled = false
  function settle(viaAck) {
    if (settled) {
      return
    }
    settled = true
    if (!viaAck) {
      log.warn(
        'Registration ack for "%s" not received in %dms; proceeding anyway'
      , device.id
      , registerTimeout
      )
    }
    resolve()
  }

  // Tell others we found a device
  push.send([ ...DeviceIntroductionMessage... ])

  privateTracker.once('register', function() {
    settle(true)
  })
  setTimeout(function() {
    settle(false)
  }, registerTimeout)
})
```

- On a normal add the ack resolves first; the timer is an inert no-op (guarded by `settled`). **No behavioral change in the healthy path.**
- The only change is in the lost-ack case: the provider proceeds instead of hanging forever.

## On proceeding without the ack

A fair question: what if the ack never arrived because the device was never actually registered (e.g. the processor/DB save failed), rather than the ack merely being lost in transit? The introduction save and the ack are independent steps, and the timeout only fires when the closure has been blocked for 15s. Proceeding then lets `check()` run and operate on the device through the normal lifecycle (which can retry/clean up) instead of leaving it silently wedged forever — i.e. it favors recovery over a permanent block. The timeout only adds latency in the already-broken lost-ack case; the happy path is unchanged.

If you'd prefer the timeout to be configurable via a CLI option rather than a constant, I'm happy to adjust.

## Verification

Reproduced by repeatedly rebooting in-use devices: without the change the devices stuck at `Providing 0 of N; ignoring` and never recovered; with the change the same reboot cycles recovered every time once registration resolved, and no duplicate device records were created.

Ran `eslint` (the lint gate `npm test` enforces) on the changed file — no new errors or warnings. The change is one function, ES5, conforms to the existing style (no semicolons, leading commas), touches no other files, and does not change the `version` field.
