### PR TITLE
Use Unspecified SAML authn context for Azure AD SSO

### DIFF
--- a/lib/units/auth/saml2.js
+++ b/lib/units/auth/saml2.js
@@ -17,6 +17,9 @@ var jwtutil = require('../../util/jwtutil')
 
 const dbapi = require('../../db/api')
 
+var AUTHN_CONTEXT_UNSPECIFIED =
+  'urn:oasis:names:tc:SAML:2.0:ac:classes:Unspecified'
+
 module.exports = function(options) {
   var log = logger.createLogger('auth-saml2')
   var app = express()
@@ -54,6 +57,7 @@ module.exports = function(options) {
   , wantAuthnResponseSigned: options.saml.wantAuthnResponseSigned
   , callbackUrl: options.saml.callbackUrl
   , idpCert: fs.readFileSync(options.saml.certPath).toString()
+  , authnContext: [AUTHN_CONTEXT_UNSPECIFIED]
   }
 
   if (options.saml.audience) {
@@ -90,12 +94,12 @@ module.exports = function(options) {
   app.post(
     '/auth/saml/callback'
   , function(req, res) {
-      if (req.user.email) {
+      if (req.user.nameID) {
         res.redirect(urlutil.addParams(options.appUrl, {
           jwt: jwtutil.encode({
             payload: {
-              email: req.user.email
-            , name: req.user.email.split('@', 1).join('')
+              email: req.user.nameID
+            , name: req.user.nameID.split('@', 1).join('')
             }
           , secret: options.secret
           , header: {


### PR DESCRIPTION
Azure AD rejects PasswordProtectedTransport when users authenticate with MFA or passwordless. Also read the user email from nameID, which is what Microsoft Entra ID provides by default.