### PR TITLE
feat(api): add an admin only Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Thank you to all the people who have already contributed to STF!
   - Set the default groups quotas applicable to all users
   - Set the groups quotas applicable to a specific user
 * Simple REST [API](doc/API.md)
+* Prometheus [metrics](doc/METRICS.md)
 
 ## Status
 

--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -1,0 +1,131 @@
+# Metrics
+
+STF exposes the counters of the whole platform through the `GET /api/v1/metrics` operation of the
+[API](API.md), using the [Prometheus text exposition format][exposition-format].
+
+The operation is a privileged one: it is tagged `admin` in the API specification and the controller
+checks the privilege of the caller as well, so it is reserved to the administrator user of the
+platform whether the caller authenticates with an access token or with a browser session. This is
+required because the returned counters cover all the devices, users and groups whatever the group
+they belong to, which a simple user is not allowed to see.
+
+The counters are computed when the endpoint is scraped, not on a timer, so the returned values are
+always those of the very moment the Prometheus server asked for them.
+
+## Exposed metrics
+
+| Metric | Type | Labels | Description |
+| ------ | ---- | ------ | ----------- |
+| `stf_devices_total` | gauge | | Number of devices known to STF, whether they are present or not |
+| `stf_devices_by_state` | gauge | `state` | Number of devices per aggregate device state |
+| `stf_devices_available` | gauge | | Number of devices in the `available` state |
+| `stf_devices_busy` | gauge | | Number of devices in the `busy` state |
+| `stf_providers_total` | gauge | | Number of distinct providers serving at least one present device |
+| `stf_users_total` | gauge | | Number of users known to STF |
+| `stf_users_by_privilege` | gauge | `privilege` | Number of users per privilege (`root`, `admin`, `user`) |
+| `stf_groups_total` | gauge | | Number of groups known to STF |
+| `stf_groups_active` | gauge | | Number of groups which are currently active |
+| `stf_groups_by_state` | gauge | `state` | Number of groups per group state (`pending`, `ready`, `waiting`) |
+| `stf_groups_by_class` | gauge | `class` | Number of groups per group class (`once`, `bookable`, `standard`, `hourly`, ...) |
+
+The `app="stf"` label is added to every metric, and the standard `process_*` and `nodejs_*` metrics
+of the API process are exposed as well.
+
+The `state` label of `stf_devices_by_state` holds the aggregate device state, computed with the same
+state machine as the one the device list uses:
+
+| State | Meaning |
+| ----- | ------- |
+| `absent` | The device is not plugged to any provider |
+| `offline` | The device is present but `adb` reports it offline |
+| `unauthorized` | The device is present but `adb` is not authorized to use it |
+| `preparing` | The device is online but not ready yet |
+| `available` | The device is ready and owned by nobody |
+| `busy` | The device is ready and owned by a user |
+| `present` | The device is present and currently being connected or authorized |
+
+The `using` and `automation` states of the device list are not exposed since they only make sense
+for a given user session.
+
+Every label value is known in advance, so a counter which drops to zero is exported as zero instead
+of vanishing, and a device or a group holding an unexpected value can't create new time series.
+
+## Scraping the endpoint
+
+The operation uses the same authentication as the rest of the API, so the Prometheus server needs
+the access token of an administrator user. Generate one from the STF UI, in
+*Settings* > *Keys* > *Access Tokens*, while logged in as the administrator.
+
+```yaml
+scrape_configs:
+  - job_name: stf
+    metrics_path: /api/v1/metrics
+    scheme: http
+    authorization:
+      type: Bearer
+      credentials: <STF_ADMIN_ACCESS_TOKEN>
+    static_configs:
+      - targets: ['stf.example.org:7100']
+```
+
+Errors are reported the way the rest of the API reports them, as a JSON body: `401` when the token
+is missing or invalid, `403` when the token belongs to a simple user, and `500` when the counters
+can't be read from the database. Only the successful response uses the Prometheus text format,
+since that is what the format is specified for.
+
+## Setting up a minimal test environment
+
+Start STF as usual, for instance with the [docker-compose.yaml](../docker-compose.yaml) of this
+repository, then add a Prometheus server and a Grafana instance next to it:
+
+```yaml
+services:
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+
+  grafana:
+    image: grafana/grafana:11.5.1
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+```
+
+With a `prometheus.yml` holding the scrape configuration above and a `15s` scrape interval:
+
+```yaml
+global:
+  scrape_interval: 15s
+```
+
+Check that the endpoint answers, then that Prometheus scrapes it:
+
+```bash
+curl -H "Authorization: Bearer $STF_ADMIN_ACCESS_TOKEN" http://localhost:7100/api/v1/metrics
+```
+
+```
+# HELP stf_devices_total Number of devices known to STF, whether they are present or not
+# TYPE stf_devices_total gauge
+stf_devices_total{app="stf"} 3
+# HELP stf_devices_by_state Number of devices per aggregate device state
+# TYPE stf_devices_by_state gauge
+stf_devices_by_state{state="absent",app="stf"} 1
+stf_devices_by_state{state="available",app="stf"} 1
+stf_devices_by_state{state="busy",app="stf"} 1
+...
+```
+
+The target then shows up as `UP` on http://localhost:9090/targets, and Grafana can be pointed at
+`http://prometheus:9090` to graph the series, for example the ratio of devices in use:
+
+```
+sum(stf_devices_busy) / sum(stf_devices_total)
+```
+
+[exposition-format]: <https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format>

--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -1541,6 +1541,14 @@ dbapi.saveDeviceIdentity = function(serial, identity) {
   }))
 }
 
+// Returns every device, whatever its group; reserved to privileged (admin) operations
+dbapi.getDevices = function() {
+  return db.run(r.table('devices'))
+    .then(function(cursor) {
+      return cursor.toArray()
+    })
+}
+
 dbapi.loadDevices = function(groups) {
   return db.run(r.table('devices').filter(function(device) {
     return r.expr(groups).contains(device('group')('id'))

--- a/lib/units/api/controllers/metrics.js
+++ b/lib/units/api/controllers/metrics.js
@@ -1,0 +1,41 @@
+/**
+* Copyright © 2026 Matan Baruch <matan.baruch@unity3d.com> - Licensed under the Apache license 2.0
+**/
+
+const Promise = require('bluebird')
+
+const dbapi = require('../../../db/api')
+const apiutil = require('../../../util/apiutil')
+const metrics = require('../../../util/metrics')
+
+// Counters are computed on scrape rather than on a timer, so that the returned values are always
+// the ones of the very moment the Prometheus server asked for them
+function getMetrics(req, res) {
+  // The admin tag of the operation is only enforced by the security handler on the access token
+  // authentication path, not on the browser session one, hence this explicit check
+  if (req.user.privilege === apiutil.USER) {
+    apiutil.respond(res, 403, 'Forbidden: privileged operation (admin)')
+    return
+  }
+
+  Promise.all([
+    dbapi.getDevices()
+  , dbapi.getUsers()
+  , dbapi.getGroups()
+  ])
+  .then(function(results) {
+    metrics.update(results[0], results[1], results[2])
+    return metrics.register.metrics()
+  })
+  .then(function(body) {
+    res.set('Content-Type', metrics.register.contentType)
+    res.status(200).send(body)
+  })
+  .catch(function(err) {
+    apiutil.internalError(res, 'Failed to get metrics: ', err.stack)
+  })
+}
+
+module.exports = {
+  getMetrics: getMetrics
+}

--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -34,6 +34,8 @@ tags:
     description: Groups Operations
   - name: admin 
     description: Privileged Operations
+  - name: metrics
+    description: Metrics Operations
 paths:
   /groups:
     x-swagger-router-controller: groups
@@ -2199,6 +2201,33 @@ paths:
               * 500: Internal Server Error
               * 503: Service Unavailable => server too busy or a lock on a resource is pending
               * 504: Gateway Time-out => server is not responding
+          schema:
+            $ref: "#/definitions/UnexpectedErrorResponse"
+      security:
+        - accessTokenAuth: []
+  /metrics:
+    x-swagger-router-controller: metrics
+    get:
+      summary: Gets the platform metrics
+      description: Returns the device, user and group counters of the whole platform using the Prometheus text exposition format; this is a privileged operation reserved to the administrator user because the returned counters cover all the objects of the platform, whatever the group they belong to
+      operationId: getMetrics
+      produces:
+        - text/plain
+        - application/json
+      tags:
+        - metrics
+        - admin
+      responses:
+        "200":
+          description: Platform metrics using the Prometheus text exposition format
+          schema:
+            type: string
+        default:
+          description: >
+            Unexpected Error:
+              * 401: Unauthorized => bad credentials
+              * 403: Forbidden => privileged operation (admin)
+              * 500: Internal Server Error
           schema:
             $ref: "#/definitions/UnexpectedErrorResponse"
       security:

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -1,0 +1,224 @@
+/**
+* Copyright © 2026 Matan Baruch <matan.baruch@unity3d.com> - Licensed under the Apache license 2.0
+**/
+
+const client = require('prom-client')
+
+const apiutil = require('./apiutil')
+const wire = require('../wire')
+
+const metrics = Object.create(null)
+
+// Aggregate device states, computed the same way as the device list does in
+// res/app/components/stf/device/enhance-device/enhance-device-service.js; the 'using' and
+// 'automation' states are not computed here since they only make sense for a given user session
+metrics.DEVICE_STATES = [
+  'absent'
+, 'present'
+, 'offline'
+, 'unauthorized'
+, 'preparing'
+, 'available'
+, 'busy'
+]
+
+metrics.GROUP_STATES = [apiutil.PENDING, apiutil.READY, apiutil.WAITING]
+metrics.GROUP_CLASSES = Object.keys(apiutil.CLASS_DURATION)
+metrics.USER_PRIVILEGES = [apiutil.ROOT, apiutil.ADMIN, apiutil.USER]
+
+const register = new client.Registry()
+
+register.setDefaultLabels({app: 'stf'})
+client.collectDefaultMetrics({register: register})
+
+const gauges = {
+  devicesTotal: new client.Gauge({
+    name: 'stf_devices_total'
+  , help: 'Number of devices known to STF, whether they are present or not'
+  , registers: [register]
+  })
+, devicesByState: new client.Gauge({
+    name: 'stf_devices_by_state'
+  , help: 'Number of devices per aggregate device state'
+  , labelNames: ['state']
+  , registers: [register]
+  })
+, devicesAvailable: new client.Gauge({
+    name: 'stf_devices_available'
+  , help: 'Number of devices in the available state'
+  , registers: [register]
+  })
+, devicesBusy: new client.Gauge({
+    name: 'stf_devices_busy'
+  , help: 'Number of devices in the busy state'
+  , registers: [register]
+  })
+, providersTotal: new client.Gauge({
+    name: 'stf_providers_total'
+  , help: 'Number of distinct providers serving at least one present device'
+  , registers: [register]
+  })
+, usersTotal: new client.Gauge({
+    name: 'stf_users_total'
+  , help: 'Number of users known to STF'
+  , registers: [register]
+  })
+, usersByPrivilege: new client.Gauge({
+    name: 'stf_users_by_privilege'
+  , help: 'Number of users per privilege'
+  , labelNames: ['privilege']
+  , registers: [register]
+  })
+, groupsTotal: new client.Gauge({
+    name: 'stf_groups_total'
+  , help: 'Number of groups known to STF'
+  , registers: [register]
+  })
+, groupsActive: new client.Gauge({
+    name: 'stf_groups_active'
+  , help: 'Number of groups which are currently active'
+  , registers: [register]
+  })
+, groupsByState: new client.Gauge({
+    name: 'stf_groups_by_state'
+  , help: 'Number of groups per group state'
+  , labelNames: ['state']
+  , registers: [register]
+  })
+, groupsByClass: new client.Gauge({
+    name: 'stf_groups_by_class'
+  , help: 'Number of groups per group class'
+  , labelNames: ['class']
+  , registers: [register]
+  })
+}
+
+function zeroFill(values) {
+  return values.reduce(function(counts, value) {
+    counts[value] = 0
+    return counts
+  }, Object.create(null))
+}
+
+// Counts only the already known label values so that a corrupted database row can't create an
+// unbounded number of time series
+function count(counts, value) {
+  const current = counts[value]
+
+  if (typeof current === 'number') {
+    counts[value] = current + 1
+  }
+}
+
+function setLabeled(gauge, label, counts) {
+  gauge.reset()
+  Object.keys(counts).forEach(function(value) {
+    const labels = Object.create(null)
+
+    labels[label] = value
+    gauge.set(labels, counts[value])
+  })
+}
+
+metrics.deviceState = function(device) {
+  if (!device.present) {
+    return 'absent'
+  }
+  switch (device.status) {
+    case wire.DeviceStatus.OFFLINE:
+      return 'offline'
+    case wire.DeviceStatus.UNAUTHORIZED:
+      return 'unauthorized'
+    case wire.DeviceStatus.ONLINE:
+      if (!device.ready) {
+        return 'preparing'
+      }
+      return device.owner ? 'busy' : 'available'
+    default:
+      return 'present'
+  }
+}
+
+metrics.aggregateDevices = function(devices) {
+  const stats = {
+    total: devices.length
+  , available: 0
+  , busy: 0
+  , providers: 0
+  , byState: zeroFill(metrics.DEVICE_STATES)
+  }
+  const providers = Object.create(null)
+
+  devices.forEach(function(device) {
+    const state = metrics.deviceState(device)
+
+    count(stats.byState, state)
+
+    if (state === 'available') {
+      stats.available += 1
+    }
+    if (state === 'busy') {
+      stats.busy += 1
+    }
+    if (device.present && device.provider && device.provider.name) {
+      providers[device.provider.name] = true
+    }
+  })
+  stats.providers = Object.keys(providers).length
+  return stats
+}
+
+metrics.aggregateUsers = function(users) {
+  const stats = {
+    total: users.length
+  , byPrivilege: zeroFill(metrics.USER_PRIVILEGES)
+  }
+
+  users.forEach(function(user) {
+    count(stats.byPrivilege, user.privilege)
+  })
+  return stats
+}
+
+metrics.aggregateGroups = function(groups) {
+  const stats = {
+    total: groups.length
+  , active: 0
+  , byState: zeroFill(metrics.GROUP_STATES)
+  , byClass: zeroFill(metrics.GROUP_CLASSES)
+  }
+
+  groups.forEach(function(group) {
+    if (group.isActive) {
+      stats.active += 1
+    }
+    count(stats.byState, group.state)
+    count(stats.byClass, group.class)
+  })
+  return stats
+}
+
+metrics.update = function(devices, users, groups) {
+  const deviceStats = metrics.aggregateDevices(devices)
+  const userStats = metrics.aggregateUsers(users)
+  const groupStats = metrics.aggregateGroups(groups)
+
+  gauges.devicesTotal.set(deviceStats.total)
+  gauges.devicesAvailable.set(deviceStats.available)
+  gauges.devicesBusy.set(deviceStats.busy)
+  gauges.providersTotal.set(deviceStats.providers)
+  setLabeled(gauges.devicesByState, 'state', deviceStats.byState)
+
+  gauges.usersTotal.set(userStats.total)
+  setLabeled(gauges.usersByPrivilege, 'privilege', userStats.byPrivilege)
+
+  gauges.groupsTotal.set(groupStats.total)
+  gauges.groupsActive.set(groupStats.active)
+  setLabeled(gauges.groupsByState, 'state', groupStats.byState)
+  setLabeled(gauges.groupsByClass, 'class', groupStats.byClass)
+}
+
+metrics.register = register
+metrics.gauges = gauges
+
+module.exports = metrics

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "openid": "^2.0.13",
     "passport": "^0.6.0",
     "passport-oauth2": "^1.1.2",
+    "prom-client": "^15.1.3",
     "protobufjs": "^5.0.3",
     "proxy-addr": "^2.0.7",
     "pug": "^3.0.3",

--- a/test/util/metrics.js
+++ b/test/util/metrics.js
@@ -1,0 +1,157 @@
+var chai = require('chai')
+var expect = chai.expect
+
+var apiutil = require('../../lib/util/apiutil')
+var wire = require('../../lib/wire')
+var metrics = require('../../lib/util/metrics')
+
+function device(properties) {
+  return Object.assign({
+    serial: 'serial'
+  , present: true
+  , ready: true
+  , status: wire.DeviceStatus.ONLINE
+  , owner: null
+  }, properties)
+}
+
+describe('Metrics', function() {
+  describe('deviceState', function() {
+    it('should report an unplugged device as absent whatever its other fields', function() {
+      expect(metrics.deviceState(device({present: false}))).to.equal('absent')
+      expect(metrics.deviceState(device({
+        present: false
+      , owner: {email: 'someone@example.org'}
+      }))).to.equal('absent')
+    })
+
+    it('should report the adb status of a present device', function() {
+      expect(metrics.deviceState(device({status: wire.DeviceStatus.OFFLINE})))
+        .to.equal('offline')
+      expect(metrics.deviceState(device({status: wire.DeviceStatus.UNAUTHORIZED})))
+        .to.equal('unauthorized')
+    })
+
+    it('should report a not yet prepared online device as preparing', function() {
+      expect(metrics.deviceState(device({ready: false}))).to.equal('preparing')
+    })
+
+    it('should report a ready online device as available or busy according to its owner',
+      function() {
+        expect(metrics.deviceState(device())).to.equal('available')
+        expect(metrics.deviceState(device({owner: {email: 'someone@example.org'}})))
+          .to.equal('busy')
+      }
+    )
+
+    it('should report a device being connected or authorized as present', function() {
+      expect(metrics.deviceState(device({status: wire.DeviceStatus.CONNECTING})))
+        .to.equal('present')
+      expect(metrics.deviceState(device({status: wire.DeviceStatus.AUTHORIZING})))
+        .to.equal('present')
+    })
+  })
+
+  describe('aggregateDevices', function() {
+    it('should zero fill every known state so that no time serie ever disappears', function() {
+      var stats = metrics.aggregateDevices([])
+
+      expect(Object.keys(stats.byState).sort()).to.deep.equal(metrics.DEVICE_STATES.slice().sort())
+      metrics.DEVICE_STATES.forEach(function(state) {
+        expect(stats.byState[state]).to.equal(0)
+      })
+    })
+
+    it('should count the devices per state', function() {
+      var stats = metrics.aggregateDevices([
+        device()
+      , device({owner: {email: 'someone@example.org'}})
+      , device({ready: false})
+      , device({present: false})
+      ])
+
+      expect(stats.total).to.equal(4)
+      expect(stats.available).to.equal(1)
+      expect(stats.busy).to.equal(1)
+      expect(stats.byState.available).to.equal(1)
+      expect(stats.byState.busy).to.equal(1)
+      expect(stats.byState.preparing).to.equal(1)
+      expect(stats.byState.absent).to.equal(1)
+    })
+
+    it('should count the distinct providers of the present devices only', function() {
+      var stats = metrics.aggregateDevices([
+        device({provider: {name: 'provider1'}})
+      , device({provider: {name: 'provider1'}})
+      , device({provider: {name: 'provider2'}})
+      , device({present: false, provider: {name: 'provider3'}})
+      , device({provider: null})
+      ])
+
+      expect(stats.providers).to.equal(2)
+    })
+  })
+
+  describe('aggregateUsers', function() {
+    it('should count the users per privilege and ignore the unknown ones', function() {
+      var stats = metrics.aggregateUsers([
+        {privilege: apiutil.ADMIN}
+      , {privilege: apiutil.USER}
+      , {privilege: apiutil.USER}
+      , {privilege: 'wat'}
+      ])
+
+      expect(stats.total).to.equal(4)
+      expect(stats.byPrivilege[apiutil.ADMIN]).to.equal(1)
+      expect(stats.byPrivilege[apiutil.USER]).to.equal(2)
+      expect(stats.byPrivilege[apiutil.ROOT]).to.equal(0)
+      expect(stats.byPrivilege.wat).to.be.an('undefined')
+    })
+  })
+
+  describe('aggregateGroups', function() {
+    it('should count the active groups using isActive and not the group state', function() {
+      var stats = metrics.aggregateGroups([
+        {isActive: true, state: apiutil.READY, class: apiutil.STANDARD}
+      , {isActive: false, state: apiutil.READY, class: apiutil.ONCE}
+      , {isActive: false, state: apiutil.PENDING, class: apiutil.ONCE}
+      ])
+
+      expect(stats.total).to.equal(3)
+      expect(stats.active).to.equal(1)
+      expect(stats.byState[apiutil.READY]).to.equal(2)
+      expect(stats.byState[apiutil.PENDING]).to.equal(1)
+      expect(stats.byState[apiutil.WAITING]).to.equal(0)
+      expect(stats.byClass[apiutil.ONCE]).to.equal(2)
+      expect(stats.byClass[apiutil.STANDARD]).to.equal(1)
+    })
+  })
+
+  describe('update', function() {
+    it('should expose the counters using the Prometheus text exposition format', function() {
+      metrics.update([device(), device({present: false})], [{privilege: apiutil.ADMIN}], [])
+
+      return metrics.register.metrics().then(function(body) {
+        expect(body).to.contain('stf_devices_total{app="stf"} 2')
+        expect(body).to.contain('stf_devices_available{app="stf"} 1')
+        expect(body).to.contain('stf_users_total{app="stf"} 1')
+        expect(body).to.contain('stf_groups_total{app="stf"} 0')
+        expect(body).to.contain('stf_devices_by_state{state="absent",app="stf"} 1')
+      })
+    })
+
+    it('should not leak the previous values of a label', function() {
+      metrics.update([device({owner: {email: 'someone@example.org'}})], [], [])
+
+      return metrics.register.metrics()
+        .then(function(body) {
+          expect(body).to.contain('stf_devices_by_state{state="busy",app="stf"} 1')
+          metrics.update([], [], [])
+          return metrics.register.metrics()
+        })
+        .then(function(body) {
+          expect(body).to.contain('stf_devices_by_state{state="busy",app="stf"} 0')
+        })
+    })
+  })
+})


### PR DESCRIPTION
Replaces #860. Same feature, rebuilt from scratch on a dedicated branch as a single commit, with every point you raised addressed.

The endpoint is `GET /api/v1/metrics`. It is tagged `admin` so only the administrator user can read it, and it returns the device, user and group counters of the platform in the Prometheus text exposition format. Counters are computed on scrape, so there is no background service and no timer anywhere in the PR.

## Your comments, one by one

1. **Access control.** The operation is tagged `admin`, and because it is privileged it now calls `dbapi.getDevices()` directly the way you suggested. `getDeviceMetrics()` is gone. One thing I hit while doing this: the `admin` tag is only enforced by `securityHandlers.accessTokenAuth()` on the access token path. The browser session branch below it calls `next()` without looking at the operation tags at all, so a logged in simple user can reach any `admin` operation from the browser. I added an explicit `req.user.privilege` check in the controller to close it here. No other controller does that today, so the session path is probably worth a separate look.
2. **No service code in `api/index.js`.** That file is untouched. Everything is in the `metrics` controller plus `lib/util/metrics.js`, which holds only the registry, the gauges and the pure aggregation functions.
3. **No `log.debug`.** There is no logging at all in the new code, and nothing runs every 30s anymore.
4. **No dead code.** `lib/util/metrics-hooks.js` and `lib/util/metrics-collector.js` are both deleted. Every line in this PR is reachable from the endpoint.
5. **Dedicated branch, single commit, signed off.**
6. **Test environment.** `doc/METRICS.md` has the scrape config, a docker compose snippet for Prometheus and Grafana, the curl command and the expected output, so you can see it working without reading the code.
7. **Why Prometheus.** It is what our monitoring already speaks, and the cost here is one route and one dependency. The endpoint is a plain text page behind the existing API auth. If someone later needs a different backend they can scrape this and translate, or add a second controller next to it. Nothing in this design blocks that.
8. **Copyright headers** now carry my name and email.
9. **JSON.** The 200 body has to be the Prometheus text format, that is what a scraper parses and the spec defines no JSON equivalent. `produces: text/plain` is declared on the operation so it is explicit in the API. Every error response is JSON like the rest of the API: 401, 403 and 500 all go through `apiutil`.
10. **No UI changes.** `res/app/group-list/group-list-controller.js` is untouched. This is backend only.

Also dropped since #860: the `stf_user_quota_usage_percent` gauge. It was labeled with user emails, which put PII in `/metrics` and made the series unbounded in cardinality.

Two real bugs from the old version are fixed. `devices.status` holds the numeric `wire.DeviceStatus` enum, not the strings `available` and `busy`, so those two counters were always 0. Groups use `isActive` and the states `pending`, `ready` and `waiting`, there is no `active` state, so the active group count was always 0 as well. Device states are now derived with the same state machine the device list uses in `enhance-device-service.js`, and every label value is known up front, so a counter that drops to zero is exported as zero instead of vanishing from the output.

## What it returns

| Metric | Labels | Description |
| ------ | ------ | ----------- |
| `stf_devices_total` | | Devices known to STF, present or not |
| `stf_devices_by_state` | `state` | Devices per aggregate device state |
| `stf_devices_available` | | Devices in the `available` state |
| `stf_devices_busy` | | Devices in the `busy` state |
| `stf_providers_total` | | Distinct providers serving at least one present device |
| `stf_users_total` | | Users known to STF |
| `stf_users_by_privilege` | `privilege` | Users per privilege |
| `stf_groups_total` | | Groups known to STF |
| `stf_groups_active` | | Groups currently active |
| `stf_groups_by_state` | `state` | Groups per group state |
| `stf_groups_by_class` | `class` | Groups per group class |

The `state` label values are `absent`, `present`, `offline`, `unauthorized`, `preparing`, `available` and `busy`. The `using` and `automation` states of the device list are not exposed since they only mean something inside a user session.

## Verification

1. `gulp lint`: 0 errors, and no new warnings in the added files
2. `test/util/metrics.js`: 12 tests covering the state machine, the aggregation and the label reset
3. The swagger spec loads and `/metrics` routes to the controller
4. Controller checked both ways: a simple user gets a 403 JSON body, an admin gets 200 with `Content-Type: text/plain; version=0.0.4; charset=utf-8` and correct counters

Note on the test file: `npm test` is `gulp test`, which runs lint and the version check only, there is no mocha runner wired up in this repo. The new file follows the existing `test/util/*` convention and runs with `mocha test/util/metrics.js`. Happy to wire a runner in a separate PR if you want the suite actually executed in CI.
