### PR TITLE
Bump minitouch-prebuilt to 1.3.1

### DIFF
--- a/.semaphore/deploy_npmjs.yml
+++ b/.semaphore/deploy_npmjs.yml
@@ -9,6 +9,7 @@ blocks:
             - install-package libzmq3-dev libprotobuf-dev graphicsmagick yasm gulp python3 --update
             - sem-version node 20
             - checkout
+            - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
             - npm install
             - npm publish --access=public
       secrets:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@devicefarmer/adbkit-apkreader": "^3.2.4",
     "@devicefarmer/adbkit-monkey": "^1.2.1",
     "@devicefarmer/minicap-prebuilt": "^2.7.3",
-    "@devicefarmer/minitouch-prebuilt": "^1.3.0",
+    "@devicefarmer/minitouch-prebuilt": "^1.3.1",
     "@devicefarmer/please-update-dependencies": "^2.0.2",
     "@devicefarmer/stf-appstore-db": "^1.0.0",
     "@devicefarmer/stf-browser-db": "^1.0.2",


### PR DESCRIPTION
## Summary
- Bump `@devicefarmer/minitouch-prebuilt` to `^1.3.1` to pick up the `/dev/input` numeric-ordering fix and Android 15+ page-size alignment (see [minitouch v1.3.1 release notes](https://github.com/DeviceFarmer/minitouch/releases/tag/v1.3.1)).
- Update the npmjs deploy pipeline's token handling: it previously relied on the `npmjs` Semaphore secret mounting a pre-baked `.npmrc` file directly, which was built around npm's classic tokens (now removed, see [npm's Nov 2025 security update](https://github.blog/changelog/2025-11-05-npm-security-update-classic-token-creation-disabled-and-granular-token-changes/)). Only granular access tokens exist now, so the pipeline writes `~/.npmrc` explicitly from an `NPM_TOKEN` env var, matching the pattern in `devicefarmer/minitouch`.

## Action required in Semaphore
The `npmjs` secret for this project needs to expose an `NPM_TOKEN` env var (a granular access token scoped to `@devicefarmer/*` packages, write access, 2FA-bypass enabled for CI, 90-day max expiry) instead of mounting a raw `.npmrc` file.

## Test plan
- [ ] Confirm `npm install` resolves `minitouch-prebuilt@1.3.1`
- [ ] Update the `npmjs` Semaphore secret to the `NPM_TOKEN` format before merging/tagging a release
- [ ] Push a real release tag after merge and confirm `Deploy to npmjs` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)