### PR TITLE
Bump minitouch-prebuilt to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@devicefarmer/adbkit-monkey": "^1.2.1",
     "@devicefarmer/minicap-prebuilt": "^2.7.3",
     "@devicefarmer/minirev-prebuilt": "^1.0.0",
-    "@devicefarmer/minitouch-prebuilt": "^1.3.1",
+    "@devicefarmer/minitouch-prebuilt": "^1.3.2",
     "@devicefarmer/please-update-dependencies": "^2.0.2",
     "@devicefarmer/stf-appstore-db": "^1.0.0",
     "@devicefarmer/stf-browser-db": "^1.0.2",


### PR DESCRIPTION
Raises the minitouch floor to the version that actually loads on Android 13 and 14.

1.3.1 fails to link on API 33/34:

```
minitouch says: "CANNOT LINK EXECUTABLE "/data/local/tmp/minitouch":
can't enable GNU RELRO protection for "/data/local/tmp/minitouch": Out of memory"
```

The device registers, sits at `Preparing`, and never becomes usable. DeviceFarmer/minitouch#26 fixed it in 1.3.2 by building with NDK 29, which sizes the writable `LOAD` segment to cover `PT_GNU_RELRO`. API 35+ tolerated the overrun, which is why it only shows up on 13 and 14.

`^1.3.1` already resolves 1.3.2 for a fresh install, so this is mostly about the floor: anyone resolving from a cache or an older lock still gets the broken binary, and the range should not permit a version that cannot start.

## Verification

Run on a real STF farm on EKS, one emulator per Android version, against two branches, 9 runs per round. Touch was driven through the STF web UI with Playwright and confirmed by the streamed screen actually changing, not just by the binary loading.

| Android | API | served | input node | linker errors | touch via UI |
|---|---|---|---|---|---|
| 13 | 33 | yes | event2 | 0 | works |
| 14 | 34 | yes | event2 | 0 | works |
| 15 | 35 | yes | event2 | 0 | works |
| 16 | 36 | yes | event2 | 0 | works |
| 17 | 37 | yes | event2 | 0 | works |

Android 17 is `system-images;android-37.2-beta3;google_apis_ps16k;x86_64`, a 16 KB-page image, so the alignment work from DeviceFarmer/minitouch#24 still holds. Every run selected `/dev/input/event2`, so device selection from DeviceFarmer/minitouch#25 is unaffected.

Tested together with `@devicefarmer/minirev-prebuilt` 1.0.0 from #895, so both native helpers now come from published packages.
