### PR TITLE
Fix the specs that could never run, and run them from npm test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /tmp/
 package-lock.json
 yarn.lock
+/test-results/

--- a/lib/util/keyutil.js
+++ b/lib/util/keyutil.js
@@ -432,6 +432,10 @@ keyutil.parseKeyCharacterMap = function(stream) {
 
   function readableListener() {
     var chunk = stream.read()
+    if (!chunk) {
+      // Node emits a final "readable" with nothing left to read before "end".
+      return
+    }
     var i = 0
     var l = chunk.length
 

--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
     "duplicate-arguments-array": false
   },
   "scripts": {
-    "test": "gulp test",
+    "test": "gulp test && npm run test:unit",
     "prepare": "bower install && not-in-install && gulp build || in-install",
-    "local": "node lib/cli/index.js local"
+    "local": "node lib/cli/index.js local",
+    "lint": "gulp lint",
+    "test:unit": "mocha --reporter spec --recursive test/util test/wire",
+    "test:component": "karma start res/test/karma.ci.conf.js --single-run"
   },
   "dependencies": {
     "@cypress/request": "^3.0.6",
@@ -170,14 +173,13 @@
     "karma-jasmine": "^2.0.1",
     "karma-junit-reporter": "^2.0.1",
     "karma-opera-launcher": "^1.0.0",
-    "karma-phantomjs-launcher": "^1.0.4",
     "karma-safari-launcher": "^1.0.0",
     "karma-webpack": "^5.0.1",
     "less": "^4.1.3",
     "less-loader": "^11.1.3",
     "memory-fs": "^0.3.0",
+    "mocha": "^10.8.2",
     "node-libs-browser": "^2.2.1",
-    "phantomjs-prebuilt": "^2.1.16",
     "protractor": "^5.4.1",
     "protractor-html-reporter-2": "1.0.4",
     "sass": "^1.82.0",

--- a/res/app/control-panes/automation/store-account/store-account-controller.js
+++ b/res/app/control-panes/automation/store-account/store-account-controller.js
@@ -1,4 +1,4 @@
-module.exports = function StoreAccountCtrl($scope, ngTableParams, $timeout) {
+module.exports = function StoreAccountCtrl($scope, $timeout) {
   // TODO: This should come from the DB
   $scope.currentAppStore = 'google-play-store'
   $scope.deviceAppStores = {

--- a/res/app/control-panes/explorer/explorer-spec.js
+++ b/res/app/control-panes/explorer/explorer-spec.js
@@ -4,8 +4,15 @@ describe('FsCtrl', function() {
 
   var scope, ctrl
 
-  beforeEach(inject(function($rootScope, $controller) {
+  beforeEach(inject(function($rootScope, $controller, $q) {
     scope = $rootScope.$new()
+    // ExplorerCtrl lists the device root on construction, which in the app
+    // comes from the parent control pane.
+    scope.control = {
+      fslist: function() {
+        return $q.resolve({body: []})
+      }
+    }
     ctrl = $controller('ExplorerCtrl', {$scope: scope})
   }))
 

--- a/res/app/control-panes/logs/logs-spec.js
+++ b/res/app/control-panes/logs/logs-spec.js
@@ -6,10 +6,14 @@ describe('LogsCtrl', function() {
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    if (Object.keys($rootScope.LogcatService).length > 0) {
-      scope.deviceEntries = $rootScope.LogcatService
-    }
-    ctrl = $controller('LogsCtrl', {$scope: scope})
+    // The controller only reads $rootScope.LogcatService when the device list
+    // has already published it, so leave it unset here.
+    ctrl = $controller('LogsCtrl', {
+      $scope: scope
+      // $routeParams comes from ngRoute, which the pane module does not pull
+      // in on its own.
+    , $routeParams: {serial: 'test-serial'}
+    })
   }))
 
   it('should ...', inject(function() {

--- a/res/app/menu/index.js
+++ b/res/app/menu/index.js
@@ -14,7 +14,8 @@ module.exports = angular.module('stf.menu', [
   require('stf/nav-menu').name,
   require('stf/settings').name,
   require('stf/common-ui/modals/external-url-modal').name,
-  require('stf/native-url').name
+  require('stf/native-url').name,
+  require('stf/logcat').name
 ])
   .controller('MenuCtrl', require('./menu-controller'))
   .run(['$templateCache', function($templateCache) {

--- a/res/test/karma.ci.conf.js
+++ b/res/test/karma.ci.conf.js
@@ -1,0 +1,68 @@
+//
+// Headless CI variant of karma.conf.js: Chrome only, single run, JUnit output.
+//
+
+var webpackConfig = require('./../../webpack.config')
+
+module.exports = function(config) {
+  config.set({
+    frameworks: ['jasmine'],
+    files: [
+      'helpers/**/*.js',
+      '../app/**/*-spec.js'
+    ],
+
+    preprocessors: {
+      'helpers/**/*.js': ['webpack'],
+      '../**/*.js': ['webpack']
+    },
+
+    webpack: {
+      cache: true,
+      module: webpackConfig.webpack.module,
+      resolve: webpackConfig.webpack.resolve
+    },
+    webpackServer: {
+      stats: false
+    },
+
+    reporters: ['dots', 'junit'],
+
+    junitReporter: {
+      outputDir: '../../test-results/karma',
+      outputFile: 'junit.xml',
+      useBrowserName: false,
+      suite: 'component'
+    },
+
+    autoWatch: false,
+    singleRun: true,
+    concurrency: 1,
+
+    browsers: ['ChromeHeadlessCI'],
+
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-dev-shm-usage',
+          '--disable-gpu'
+        ]
+      }
+    },
+
+    captureTimeout: 120000,
+    browserNoActivityTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 2,
+
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-webpack'),
+      require('karma-chrome-launcher'),
+      require('karma-junit-reporter')
+    ]
+  })
+}

--- a/res/test/karma.conf.js
+++ b/res/test/karma.conf.js
@@ -66,7 +66,6 @@ module.exports = function(config) {
       require('karma-webpack'),
       require('karma-chrome-launcher'),
       require('karma-firefox-launcher'),
-      require('karma-phantomjs-launcher'),
       require('karma-junit-reporter'),
       require('karma-ie-launcher'),
       require('karma-safari-launcher')


### PR DESCRIPTION
`npm test` was `gulp.parallel('lint', 'run:checkversion')`, so it ran eslint and `stf -V` and nothing else. The mocha specs under `test/` and the karma specs under `res/app` were never executed, so nothing noticed that some of them could not run.

Running them for the first time, against otherwise unmodified code:

```
$ npm run test:unit
  keyutil: Uncaught TypeError: Cannot read properties of null (reading 'length')
    at ReadStream.readableListener (lib/util/keyutil.js:436:19)
  39 passing, 2 failing

$ npm run test:component
  StoreAccountCtrl FAILED  Unknown provider: ngTableParamsProvider <- ngTableParams
  MenuCtrl FAILED          Unknown provider: LogcatServiceProvider <- LogcatService
  FsCtrl FAILED, LogsCtrl FAILED
  Executed 82 of 82 (4 FAILED)
```

Fixes:

1. `keyutil.js` dereferenced `stream.read()` on the final `readable` event, where Node returns null. The `keyutil parseKeyCharacterMap` spec was already failing the last time it was run (openstf/stf#541) and passes now.
2. `StoreAccountCtrl` injected `ngTableParams`, which ng-table renamed to `NgTableParams`. It was unused in the body.
3. `stf.menu` did not depend on `stf/logcat` while `MenuCtrl` injects `LogcatService`.
4. The explorer and logs specs could not construct their controllers: one needs `scope.control`, the other `$routeParams`.

Now `npm test` gives 40 passing and `npm run test:component` gives 82 of 82.

`npm test` is that same gulp task plus the mocha specs, so it still needs no browser and the `npm test` block in `.semaphore/semaphore.yml` keeps working. karma does need a Chrome, so it stays separate as `npm run test:component` using `res/test/karma.ci.conf.js`.

`phantomjs-prebuilt` and `karma-phantomjs-launcher` are removed: unmaintained since 2018 and unused here, and `karma.conf.js` already defaulted to Chrome. The `sed '/phantomjs/d'` in `.semaphore/semaphore.yml` becomes a no-op.

Nothing is upgraded.
