### PR TITLE
Fix validateDate reading the global event instead of its parameter

### DIFF
--- a/res/app/components/stf/logcat-table/logcat-table-directive.js
+++ b/res/app/components/stf/logcat-table/logcat-table-directive.js
@@ -162,27 +162,27 @@ module.exports =
            * -... combinations
            *  in other case colour will be set to default.
            *
-           * @param {event} event object
+           * @param {event} e object
            * @returns {None} NaN
            */
         scope.validateDate = function(e) {
           var pattern = ['^(?:(?:([0-1]?\\d|2[0-3]):)?(:[0-5]\\d|[0-5]\\d):|\\d)',
             '?(:[0-5]\\d|[0-5]\\d{1,2})?(\\.[0-9]?\\d{0,2}|:[0-5]?\\d{0,1})|(\\d{0,2})'].join([])
           var regex = new RegExp(pattern, 'g')
-          var inputValue = event.srcElement.value
+          var inputValue = e.target.value
           var matchArray = inputValue.match(regex)
           var isTextValid = false
           if (matchArray) {
             matchArray.forEach(function(item, index) {
               if (item === inputValue) {
                 isTextValid = true
-                event.srcElement.style.borderColor = ''
+                e.target.style.borderColor = ''
               }
             })
           }
 
           if (isTextValid === false) {
-            event.srcElement.style.borderColor = 'red'
+            e.target.style.borderColor = 'red'
           }
         }
 

--- a/res/app/components/stf/logcat/logcat-service.js
+++ b/res/app/components/stf/logcat/logcat-service.js
@@ -5,13 +5,6 @@ module.exports = function LogcatServiceFactory(socket, FilterStringService) {
   var service = {}
   service.started = false
 
-  service.serverFilters = [
-    {
-      tag: '',
-      priority: 2
-    }
-  ]
-
   service.filters = {
     entries: [
     ],
@@ -28,7 +21,6 @@ module.exports = function LogcatServiceFactory(socket, FilterStringService) {
         },
         set: function(value) {
           _filters[prop] = value || null
-          service.serverFilters[0][prop] = value || undefined
           service.filters.filterLines()
         }
       })

--- a/res/app/control-panes/logs/logs.pug
+++ b/res/app/control-panes/logs/logs.pug
@@ -12,7 +12,7 @@
             select(ng-model='filters.priority', data-ng-options='l.name for l in filters.levelNumbers')
               option(value='') {{"Logcat Level"|translate}}
           td(width='10%')
-            input(ng-model='filters.date', type='text', placeholder='{{"Time"|translate}}', ng-keyup='validateDate(event=$event)').input-sm.form-control
+            input(ng-model='filters.date', type='text', placeholder='{{"Time"|translate}}', ng-keyup='validateDate($event)').input-sm.form-control
           td(width='8%', ng-if='$root.platform == "native"')
             input(ng-model='filters.pid', type='text', placeholder='{{"PID"|translate}}').input-sm.form-control
           td(width='8%', ng-if='$root.platform == "native"')


### PR DESCRIPTION
`scope.validateDate` in `logcat-table-directive.js` reads the global `window.event` instead of the parameter it declares. It works by accident in browsers that populate the global.

```js
scope.validateDate = function(e) {          // e declared
  var inputValue = event.srcElement.value   // and never used
```

All three accesses went through `event`. They use `e.target` now.

**Why `e.target` rather than `e.srcElement`.** bootstrap 3 pulls jQuery into `bower_components` and it loads ahead of angular, which is why `screen-directive.js` unwraps `e.originalEvent` in five places. `ng-keyup` therefore hands the handler a `jQuery.Event`, and `jQuery.Event` normalises `target` but has no `srcElement` at all. Keeping `srcElement` while switching to the parameter would have thrown a `TypeError` on every keystroke.

`logs.pug` passed the event as `validateDate(event=$event)`. In an angular expression that is an assignment, so it forwarded `$event` correctly but also left a stray `event` property on the scope. It passes `$event` directly now.

Two smaller things in the same files: the jsdoc above the function named the parameter `event` too, corrected to `e`; and `service.serverFilters` is removed, since it was written on every filter change and read nowhere (two references, both in `logcat-service.js`, no template reference, and `LogcatService` is not touched from any pug file).

Neither file has a spec covering these paths, so the check on the pug edit is the Build job compiling the templates.
