### PR TITLE
Stop the Enable KVM step racing udev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,14 @@ jobs:
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+          # trigger queues the event and returns, so the rule may not have been
+          # applied yet. Wait for the queue to drain, then set the mode directly
+          # if the node is still not writable.
+          sudo udevadm settle --timeout=30 || true
+          test -w /dev/kvm || {
+            echo "::warning::udev kvm rule did not apply, falling back to chmod"
+            sudo chmod 666 /dev/kvm
+          }
           ls -l /dev/kvm
           test -w /dev/kvm
 


### PR DESCRIPTION
The Android legs fail intermittently at `test -w /dev/kvm` with the node still showing `crw-rw---- root kvm`. The udev rule was written and reloaded, but had not been applied when the check ran.

`udevadm trigger` queues the event and returns immediately. Nothing in the step makes it wait.

```
sudo udevadm settle --timeout=30 || true
test -w /dev/kvm || {
  echo "::warning::udev kvm rule did not apply, falling back to chmod"
  sudo chmod 666 /dev/kvm
}
```

`udevadm settle` drains the queue. If the node is still not writable after that, chmod sets the mode directly, which is enough on a single-shot runner where nothing hot-plugs `/dev/kvm` afterwards.

The fallback prints a `::warning::` before it acts. Without that it would rescue the job silently, and a runner-image change that stopped the udev rule from applying at all would never surface.

Seen on the Android 12 (API 31) leg of [this run](https://github.com/matanbaruch/stf/actions/runs/32501496926/job/96832186487):

```
KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"
crw-rw---- 1 root kvm 10, 232 Aug 21 16:12 /dev/kvm
##[error]Process completed with exit code 1.
```

The rule was written, `ls -l` still showed `root kvm` with no group write, and `test -w /dev/kvm` exited 1. Four clean 16-leg runs since the fix. It is still a race, so that is not proof.

One file, eight added lines.
