### PR TITLE
Replace the for..in in urlutil.addParams with Object.assign

### DIFF
--- a/lib/util/urlutil.js
+++ b/lib/util/urlutil.js
@@ -1,13 +1,9 @@
 var url = require('url')
 
-/* eslint guard-for-in:0 */
 module.exports.addParams = function(originalUrl, params) {
   var parsed = url.parse(originalUrl, true)
   parsed.search = null
-  // TODO: change to ES6 loop
-  for (var key in params) {
-    parsed.query[key] = params[key]
-  }
+  Object.assign(parsed.query, params)
   return url.format(parsed)
 }
 


### PR DESCRIPTION
`urlutil.addParams` copied params with a `for..in` loop, so the file carried a file-wide `/* eslint guard-for-in:0 */` escape hatch and a `// TODO: change to ES6 loop`. `Object.assign` does the same copy for own properties only, which is what the code actually wants, so both the loop and the disable go away.

```js
-/* eslint guard-for-in:0 */
 module.exports.addParams = function(originalUrl, params) {
   var parsed = url.parse(originalUrl, true)
   parsed.search = null
-  // TODO: change to ES6 loop
-  for (var key in params) {
-    parsed.query[key] = params[key]
-  }
+  Object.assign(parsed.query, params)
   return url.format(parsed)
 }
```

The one semantic difference is that inherited enumerable properties are no longer copied. That is exactly what `guard-for-in` exists to enforce, and all five callers pass a fresh object literal:

| Caller | Argument |
| --- | --- |
| `lib/units/auth/mock.js:141` | `{jwt: token}` |
| `lib/units/auth/ldap.js:113` | `{jwt: token}` |
| `lib/units/auth/oauth2/index.js:71` | `{jwt: jwtutil.encode(...)}` |
| `lib/units/auth/openid.js:75` | `{jwt: token}` |
| `lib/units/auth/saml2.js:96` | `{jwt: jwtutil.encode(...)}` |

`Object.assign` is already used elsewhere in `lib/` (`units/device/plugins/solo.js`, `units/groups-engine/watchers/devices.js`) and `package.json` requires Node >= 18.20.5.

Verification: ran the new implementation against the old one on nine URL and param shapes (empty params, existing query string, key collision, repeated keys, keys needing percent-encoding, fragment preservation, falsy values). Output is byte-identical in all nine. `eslint` still reports 0 errors and 0 warnings across the project.
