### PR TITLE
Un-mute the last four rules res/.eslintrc had muted

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -101,11 +101,11 @@
     "indent": [0, 2, {"SwitchCase": 0, "VariableDeclarator": 2}], // TODO: optionally set `[2, 2, {"SwitchCase": 1, "VariableDeclarator": {"var": 2, "let": 2, "const": 3}}]` this gives too many errors
     "jsx-quotes": [2, "prefer-single"],
     "key-spacing": [2, {"beforeColon": false, "afterColon": true, "mode": "strict"}], // optionally set `[2, {"beforeColon": false, "afterColon": true, "mode": "strict", "align": "colon"}]`
-    "lines-around-comment": 2, // optionally set `[2, {"beforeBlockComment": true, "beforeLineComment": true, "allowBlockStart": true}]`
+    "lines-around-comment": [2, {"beforeBlockComment": true, "allowBlockStart": true}], // allowBlockStart because the blank line it would want at a block start is a padded-blocks error
     "linebreak-style": 0, // optionally set `[1, "unix"]`
     "max-len": [2, 100, 2, {"ignoreComments": true, "ignoreUrls": true}], // NOTE: Our limit is 80 however ESLint does not have an ignoreStrings so lets have more buffer
     "max-nested-callbacks": [1, 5],
-    "new-cap": 2, // optionally set `[2, {"capIsNewExceptions": ["Person"]}]`
+    "new-cap": [2, {"capIsNewExceptionPattern": "Service$"}], // angular services are injected under their registered PascalCase name and called as plain functions
     "new-parens": 2,
     "newline-after-var": [0, "always"], // TODO: 1 may be ok
     "no-array-constructor": 2,

--- a/res/.eslintrc
+++ b/res/.eslintrc
@@ -7,13 +7,6 @@
     "node": false,
     "jasmine": true
   },
-  "rules": {
-    // TODO: these four need code changes rather than a --fix pass
-    "no-unused-vars": 0,
-    "lines-around-comment": 0,
-    "no-use-before-define": 0,
-    "new-cap": 0
-  },
   "globals": {
     "angular": 1,
     "inject": 1,

--- a/res/app/components/stf/angular-draggabilly/angular-draggabilly-spec.js
+++ b/res/app/components/stf/angular-draggabilly/angular-draggabilly-spec.js
@@ -1,14 +1,8 @@
 describe('angularDraggabilly', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
+
     /*
      To test your directive, you need to create some html that would use your directive,
      send that through compile() then compare the results.

--- a/res/app/components/stf/angular-packery/angular-packery-directive.js
+++ b/res/app/components/stf/angular-packery/angular-packery-directive.js
@@ -19,17 +19,6 @@ module.exports = function angularPackeryDirective(PackeryService,
       }, parsedAttrs)
 
       var pckry = new PackeryService(container, options)
-      pckry.on('layoutComplete', onLayoutComplete)
-      pckry.bindResize()
-      bindDraggable()
-
-      $timeout(function() {
-        pckry.layout()
-      }, 0)
-      $timeout(function() {
-        pckry.layout()
-      }, 100)
-
       function bindDraggable() {
         if (options.draggable) {
           var draggableOptions = {}
@@ -48,6 +37,17 @@ module.exports = function angularPackeryDirective(PackeryService,
       function onLayoutComplete() {
         return true
       }
+
+      pckry.on('layoutComplete', onLayoutComplete)
+      pckry.bindResize()
+      bindDraggable()
+
+      $timeout(function() {
+        pckry.layout()
+      }, 0)
+      $timeout(function() {
+        pckry.layout()
+      }, 100)
 
       function onPanelsResized() {
         pckry.layout()

--- a/res/app/components/stf/angular-packery/angular-packery-spec.js
+++ b/res/app/components/stf/angular-packery/angular-packery-spec.js
@@ -1,13 +1,6 @@
 describe('angularPackery', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/basic-mode/basic-mode-spec.js
+++ b/res/app/components/stf/basic-mode/basic-mode-spec.js
@@ -1,13 +1,6 @@
 describe('basicMode', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/badge-icon/badge-icon-spec.js
+++ b/res/app/components/stf/common-ui/badge-icon/badge-icon-spec.js
@@ -1,13 +1,6 @@
 describe('badgeIcon', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/blur-element/blur-element-spec.js
+++ b/res/app/components/stf/common-ui/blur-element/blur-element-spec.js
@@ -1,13 +1,6 @@
 describe('blurElement', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/counter/counter-spec.js
+++ b/res/app/components/stf/common-ui/counter/counter-spec.js
@@ -1,13 +1,6 @@
 describe('counter', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/enable-autofill/enable-autofill-directive.js
+++ b/res/app/components/stf/common-ui/enable-autofill/enable-autofill-directive.js
@@ -13,7 +13,7 @@ module.exports = function enableAutofillDirective($rootElement, $cookies) {
       if (!tAttrs.method) {
         tElement.attr('method', 'post')
       }
- else {
+      else {
         if (!tAttrs.method.match(/post/i)) {
           throw new Error('Auto-fill only works with form POST method')
         }

--- a/res/app/components/stf/common-ui/enable-autofill/enable-autofill-spec.js
+++ b/res/app/components/stf/common-ui/enable-autofill/enable-autofill-spec.js
@@ -1,13 +1,6 @@
 describe('enableAutofill', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/error-message/error-message-spec.js
+++ b/res/app/components/stf/common-ui/error-message/error-message-spec.js
@@ -1,12 +1,6 @@
 describe('errorMessage', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
 
   it('should ...', function() {
 

--- a/res/app/components/stf/common-ui/fallback-image/fallback-image-spec.js
+++ b/res/app/components/stf/common-ui/fallback-image/fallback-image-spec.js
@@ -1,13 +1,6 @@
 describe('fallbackImage', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/filter-button/filter-button-spec.js
+++ b/res/app/components/stf/common-ui/filter-button/filter-button-spec.js
@@ -1,13 +1,6 @@
 describe('filterButton', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/focus-element/focus-element-spec.js
+++ b/res/app/components/stf/common-ui/focus-element/focus-element-spec.js
@@ -1,13 +1,6 @@
 describe('focusElement', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/icon-inside-input/icon-inside-input-spec.js
+++ b/res/app/components/stf/common-ui/icon-inside-input/icon-inside-input-spec.js
@@ -1,13 +1,6 @@
 describe('iconInsideInput', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/include-cached/compile-cache-service.js
+++ b/res/app/components/stf/common-ui/include-cached/compile-cache-service.js
@@ -6,7 +6,7 @@ module.exports = function($http, $templateCache, $compile) {
     if (compileFn) {
       compileFn(scope, cloneAttachFn)
     }
- else {
+    else {
       $http.get(src, {cache: $templateCache}).success(function(response) {
         var responseContents = angular.element('<div></div>').html(response).contents()
         compileFn = cache[src] = $compile(responseContents)

--- a/res/app/components/stf/common-ui/include-cached/include-cached-spec.js
+++ b/res/app/components/stf/common-ui/include-cached/include-cached-spec.js
@@ -1,13 +1,6 @@
 describe('includeCached', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/modals/save-log-modal/save-log-service.js
+++ b/res/app/components/stf/common-ui/modals/save-log-modal/save-log-service.js
@@ -17,7 +17,7 @@ module.exports =
                       , device[line].message].join('\t') + '\n'
           }
         }
- else {
+        else {
           output = {deviceOS: device[0].deviceLabel
                     , serial: device[0].serial
                     , logs: []}
@@ -100,7 +100,7 @@ module.exports =
           FileSaver.saveAs(parsedOutput,
             (window.location.href).split('/').pop() + '_logs.' + selectedExtension)
         }
-         else {
+        else {
           FileSaver.saveAs(parsedOutput,
             $scope.saveLogFileName + '.' + selectedExtension)
         }

--- a/res/app/components/stf/common-ui/ng-enter/ng-enter-spec.js
+++ b/res/app/components/stf/common-ui/ng-enter/ng-enter-spec.js
@@ -1,13 +1,6 @@
 describe('ngEnter', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/nice-tabs/nice-tabs-spec.js
+++ b/res/app/components/stf/common-ui/nice-tabs/nice-tabs-spec.js
@@ -1,13 +1,6 @@
 describe('niceTabs', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/pagination/pagination-directive.js
+++ b/res/app/components/stf/common-ui/pagination/pagination-directive.js
@@ -17,7 +17,7 @@ module.exports = function() {
       , currentPage: '='
     }
     , template: require('./pagination.pug')
-    , link: function(scope, element, attrs) {
+    , link: function(scope) {
       scope.currentPage = 1
     }
   }

--- a/res/app/components/stf/common-ui/refresh-page/refresh-page-spec.js
+++ b/res/app/components/stf/common-ui/refresh-page/refresh-page-spec.js
@@ -1,13 +1,6 @@
 describe('refreshPage', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/safe-apply/index.js
+++ b/res/app/components/stf/common-ui/safe-apply/index.js
@@ -10,7 +10,7 @@ module.exports = angular.module('stf.safe-apply', [])
                 fn()
               }
             }
- else {
+            else {
               $delegate.$apply(fn)
             }
           }

--- a/res/app/components/stf/common-ui/text-focus-select/text-focus-select-spec.js
+++ b/res/app/components/stf/common-ui/text-focus-select/text-focus-select-spec.js
@@ -1,13 +1,6 @@
 describe('textFocusSelect', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/common-ui/tooltips/tooltips-spec.js
+++ b/res/app/components/stf/common-ui/tooltips/tooltips-spec.js
@@ -1,13 +1,6 @@
 describe('tooltips', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/control/control-service.js
+++ b/res/app/components/stf/control/control-service.js
@@ -124,11 +124,11 @@ module.exports = function ControlServiceFactory(
             if (result.lastData) {
               that.clipboardContent = result.lastData
             }
- else {
+            else {
               that.clipboardContent = gettext('No clipboard data')
             }
           }
- else {
+          else {
             that.clipboardContent = gettext('Error while getting data')
           }
         })

--- a/res/app/components/stf/device-context-menu/device-context-menu-spec.js
+++ b/res/app/components/stf/device-context-menu/device-context-menu-spec.js
@@ -1,13 +1,6 @@
 describe('deviceContextMenu', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/device/device-service.js
+++ b/res/app/components/stf/device/device-service.js
@@ -108,31 +108,6 @@ module.exports = function DeviceServiceFactory($http, socket, EnhanceDeviceServi
       }
     }.bind(this)
 
-    function fetch(data) {
-      deviceService.load(data.serial)
-        .then(function(device) {
-          return changeListener({
-            important: true
-          , data: device
-          })
-        })
-        .catch(function() {})
-    }
-
-    function addListener(event) {
-      var device = get(event.data)
-      if (device) {
-        modify(device, event.data)
-        notify(event)
-      }
-      else {
-        if (options.filter(event.data)) {
-          insert(event.data)
-          notify(event)
-        }
-      }
-    }
-
     function changeListener(event) {
       var device = get(event.data)
       if (device) {
@@ -157,6 +132,33 @@ module.exports = function DeviceServiceFactory($http, socket, EnhanceDeviceServi
         }
       }
       **/
+    }
+
+    // the only call site is the commented-out block above, kept with it
+    // eslint-disable-next-line no-unused-vars
+    function fetch(data) {
+      deviceService.load(data.serial)
+        .then(function(device) {
+          return changeListener({
+            important: true
+          , data: device
+          })
+        })
+        .catch(function() {})
+    }
+
+    function addListener(event) {
+      var device = get(event.data)
+      if (device) {
+        modify(device, event.data)
+        notify(event)
+      }
+      else {
+        if (options.filter(event.data)) {
+          insert(event.data)
+          notify(event)
+        }
+      }
     }
 
     scopedSocket.on('device.add', addListener)

--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -54,23 +54,6 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
     device.enhancedStatePassive = $filter('statusNamePassive')(device.state)
   }
 
-  function enhanceDeviceDetails(device) {
-    if (device.battery) {
-      device.enhancedBatteryPercentage = (device.battery.level / device.battery.scale * 100) + '%'
-      device.enhancedBatteryHealth = $filter('batteryHealth')(device.battery.health)
-      device.enhancedBatterySource = $filter('batterySource')(device.battery.source)
-      device.enhancedBatteryStatus = $filter('batteryStatus')(device.battery.status)
-      device.enhancedBatteryTemp = device.battery.temp + '°C'
-    }
-
-    if (device.owner) {
-      device.enhancedUserProfileUrl = enhanceUserProfileUrl(device.owner.email)
-      device.enhancedUserName = device.owner.name || 'No name'
-    }
-
-    device.enhancedGroupOwnerProfileUrl = enhanceUserProfileUrl(device.group.owner.email)
-  }
-
   function enhanceUserProfileUrl(email) {
     var url
     var userProfileUrl = (function() {
@@ -88,13 +71,30 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
           userProfileUrl + email
       }
     }
- else if (email.indexOf('@') !== -1) {
+    else if (email.indexOf('@') !== -1) {
       url = 'mailto:' + email
     }
- else {
+    else {
       url = '/!#/user/' + email
     }
     return url
+  }
+
+  function enhanceDeviceDetails(device) {
+    if (device.battery) {
+      device.enhancedBatteryPercentage = (device.battery.level / device.battery.scale * 100) + '%'
+      device.enhancedBatteryHealth = $filter('batteryHealth')(device.battery.health)
+      device.enhancedBatterySource = $filter('batterySource')(device.battery.source)
+      device.enhancedBatteryStatus = $filter('batteryStatus')(device.battery.status)
+      device.enhancedBatteryTemp = device.battery.temp + '°C'
+    }
+
+    if (device.owner) {
+      device.enhancedUserProfileUrl = enhanceUserProfileUrl(device.owner.email)
+      device.enhancedUserName = device.owner.name || 'No name'
+    }
+
+    device.enhancedGroupOwnerProfileUrl = enhanceUserProfileUrl(device.group.owner.email)
   }
 
   function enhanceDeviceAppState(device) {

--- a/res/app/components/stf/filter-string/filter-string-service.js
+++ b/res/app/components/stf/filter-string/filter-string-service.js
@@ -37,7 +37,7 @@ module.exports = function FilterStringServiceFactory() {
           var regex = new RegExp(pattern, flags)
           matched = !_.isNull(str.match(regex))
         }
- else {
+        else {
           matched = true // Regex is not complete, don't filter yet
         }
         break

--- a/res/app/components/stf/image-onload/image-onload-spec.js
+++ b/res/app/components/stf/image-onload/image-onload-spec.js
@@ -1,13 +1,6 @@
 describe('imageOnload', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/install/install-service.js
+++ b/res/app/components/stf/install/install-service.js
@@ -116,7 +116,7 @@ module.exports = function InstallService(
               installation.update(50 + result.progress / 2, result.lastData)
             })
         }
- else {
+        else {
           return $http.get(installation.href + '/manifest')
             .then(function(res) {
               if (res.data.success) {

--- a/res/app/components/stf/keys/add-adb-key/add-adb-key-spec.js
+++ b/res/app/components/stf/keys/add-adb-key/add-adb-key-spec.js
@@ -1,12 +1,6 @@
 describe('addAdbKey', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
 
   it('should ...', function() {
 

--- a/res/app/components/stf/landscape/landscape-directive.js
+++ b/res/app/components/stf/landscape/landscape-directive.js
@@ -5,12 +5,6 @@ module.exports =
       , link: function(scope) {
         var body = angular.element($document[0].body)
 
-        if (typeof $window.orientation !== 'undefined') {
-          if ($window.orientation !== 0) {
-            rotateGuest(false)
-          }
-        }
-
         function rotateGuest(portrait) {
           if (portrait) {
             body.addClass('guest-portrait')
@@ -18,13 +12,19 @@ module.exports =
 
             scope.$broadcast('guest-portrait')
           }
- else {
+          else {
             body.addClass('guest-landscape')
             body.removeClass('guest-portrait')
 
             scope.$broadcast('guest-landscape')
 
             $window.scrollTo(0, 0)
+          }
+        }
+
+        if (typeof $window.orientation !== 'undefined') {
+          if ($window.orientation !== 0) {
+            rotateGuest(false)
           }
         }
 

--- a/res/app/components/stf/landscape/landscape-spec.js
+++ b/res/app/components/stf/landscape/landscape-spec.js
@@ -1,13 +1,6 @@
 describe('landscape', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/language/language-service.js
+++ b/res/app/components/stf/language/language-service.js
@@ -11,12 +11,6 @@ module.exports =
       return navigator.language || navigator.userLanguage
     }
 
-    function browserToSupportedLang(lang) {
-      // supportedLanguages.
-
-      // return lang.replace(/([A-Za-z]{2})(-|_)?([A-Za-z]{0,4})/gm, '$1')
-    }
-
     function isSupported(lang) {
       return !!supportedLanguages[lang]
     }
@@ -31,6 +25,10 @@ module.exports =
     LanguageService.detectedLanguage =
       onlySupported(detectLanguage(), LanguageService.defaultLanguage)
 
+    function updateLanguage() {
+      gettextCatalog.setCurrentLanguage(LanguageService.selectedLanguage)
+    }
+
     SettingsService.sync(
       LanguageService, {
         target: LanguageService.settingKey
@@ -38,10 +36,6 @@ module.exports =
         , defaultValue: LanguageService.detectedLanguage
       }, updateLanguage
     )
-
-    function updateLanguage() {
-      gettextCatalog.setCurrentLanguage(LanguageService.selectedLanguage)
-    }
 
     LanguageService.updateLanguage = updateLanguage
 

--- a/res/app/components/stf/logcat-table/logcat-table-directive.js
+++ b/res/app/components/stf/logcat-table/logcat-table-directive.js
@@ -17,9 +17,6 @@ module.exports =
         var maxVisibleEntries = 100
         var deviceSerial = (window.location.href).split('/').pop()
 
-        scope.started = checkLoggerServiceStatus(true)
-        scope.allowClean = checkAllowClean()
-
         function checkAllowClean() {
           if (Object.keys(LogcatService.deviceEntries).includes(deviceSerial)) {
             return LogcatService.deviceEntries[deviceSerial].allowClean
@@ -28,78 +25,27 @@ module.exports =
           return false
         }
 
-        function checkLoggerServiceStatus(loadLogs = false) {
-          var collectedLogs = []
-          var isStarted = false
-          if (Object.keys($rootScope).includes('LogcatService')) {
-            LogcatService.deviceEntries = $rootScope.LogcatService.deviceEntries
-          }
-
-          if (Object.keys(LogcatService.deviceEntries).includes(deviceSerial)) {
-            collectedLogs = LogcatService.deviceEntries[deviceSerial].logs
-            isStarted = LogcatService.deviceEntries[deviceSerial].started
-          }
-
-          if (loadLogs) {
-            restoreLogs(collectedLogs)
-          }
-          return isStarted
-        }
-
-        function limitVisibleEntries() {
-          var limiter = ''
-          if (maxVisibleEntries > maxEntriesBuffer) {
-            limiter = maxEntriesBuffer
-          }
- else {
-            limiter = maxVisibleEntries
-          }
-
-          if (element.find('tbody')[0].rows.length > limiter) {
-            removeFirstLogTableEntry()
-          }
-        }
-
-        function removeFirstLogTableEntry() {
-          element.find('tbody')[0].deleteRow(0)
-        }
-
-        LogcatService.addEntryListener = function(entry) {
-          if (deviceSerial === entry.serial) {
-            limitVisibleEntries()
-            if (LogcatService.deviceEntries[deviceSerial].logs.length > maxEntriesBuffer) {
-              LogcatService.deviceEntries[deviceSerial].logs.shift()
-            }
-            addRow(body, entry)
-          }
-        }
-
-        LogcatService.addFilteredEntriesListener = function(entries) {
-          checkLoggerServiceStatus()
-        }
-
         function shouldAutoScroll() {
           if (autoScrollDependingOnScrollPosition) {
             return scrollPosition === scrollHeight
           }
- else {
+          else {
             return true
           }
         }
-
-        function scrollListener(event) {
-          scrollPosition = event.target.scrollTop + event.target.clientHeight
-          scrollHeight = event.target.scrollHeight
-        }
-
-        var throttledScrollListener = _.throttle(scrollListener, 100)
-        parent.addEventListener('scroll', throttledScrollListener, false)
 
         function scrollToBottom() {
           parent.scrollTop = parent.scrollHeight + 20
           $timeout(function() {
             parent.scrollTop = parent.scrollHeight
           }, 10)
+        }
+
+        function clearTable() {
+          var oldBody = body
+          var newBody = document.createElement('tbody')
+          oldBody.parentNode.replaceChild(newBody, oldBody)
+          body = newBody
         }
 
         function addRow(rowParent, data, batchRequest) {
@@ -126,18 +72,6 @@ module.exports =
           }
         }
 
-        function clearTable() {
-          var oldBody = body
-          var newBody = document.createElement('tbody')
-          oldBody.parentNode.replaceChild(newBody, oldBody)
-          body = newBody
-        }
-
-        scope.clearTable = function() {
-          LogcatService.clear()
-          clearTable()
-        }
-
         function restoreLogs(collectedLogs) {
           clearTable()
 
@@ -151,6 +85,72 @@ module.exports =
               addRow(body, collectedLogs[logLine], true)
             }
           }
+        }
+
+        function checkLoggerServiceStatus(loadLogs = false) {
+          var collectedLogs = []
+          var isStarted = false
+          if (Object.keys($rootScope).includes('LogcatService')) {
+            LogcatService.deviceEntries = $rootScope.LogcatService.deviceEntries
+          }
+
+          if (Object.keys(LogcatService.deviceEntries).includes(deviceSerial)) {
+            collectedLogs = LogcatService.deviceEntries[deviceSerial].logs
+            isStarted = LogcatService.deviceEntries[deviceSerial].started
+          }
+
+          if (loadLogs) {
+            restoreLogs(collectedLogs)
+          }
+          return isStarted
+        }
+
+        function removeFirstLogTableEntry() {
+          element.find('tbody')[0].deleteRow(0)
+        }
+
+        scope.started = checkLoggerServiceStatus(true)
+        scope.allowClean = checkAllowClean()
+
+        function limitVisibleEntries() {
+          var limiter = ''
+          if (maxVisibleEntries > maxEntriesBuffer) {
+            limiter = maxEntriesBuffer
+          }
+          else {
+            limiter = maxVisibleEntries
+          }
+
+          if (element.find('tbody')[0].rows.length > limiter) {
+            removeFirstLogTableEntry()
+          }
+        }
+
+        LogcatService.addEntryListener = function(entry) {
+          if (deviceSerial === entry.serial) {
+            limitVisibleEntries()
+            if (LogcatService.deviceEntries[deviceSerial].logs.length > maxEntriesBuffer) {
+              LogcatService.deviceEntries[deviceSerial].logs.shift()
+            }
+            addRow(body, entry)
+          }
+        }
+
+        LogcatService.addFilteredEntriesListener = function() {
+          checkLoggerServiceStatus()
+        }
+
+        function scrollListener(event) {
+          scrollPosition = event.target.scrollTop + event.target.clientHeight
+          scrollHeight = event.target.scrollHeight
+        }
+
+        var throttledScrollListener = _.throttle(scrollListener, 100)
+        parent.addEventListener('scroll', throttledScrollListener, false)
+
+        scope.clearTable = function() {
+          LogcatService.clear()
+          clearTable()
         }
 
         /**
@@ -175,7 +175,7 @@ module.exports =
           var matchArray = inputValue.match(regex)
           var isTextValid = false
           if (matchArray) {
-            matchArray.forEach(function(item, index) {
+            matchArray.forEach(function(item) {
               if (item === inputValue) {
                 isTextValid = true
                 e.target.style.borderColor = ''

--- a/res/app/components/stf/logcat-table/logcat-table-spec.js
+++ b/res/app/components/stf/logcat-table/logcat-table-spec.js
@@ -1,13 +1,6 @@
 describe('logcatTable', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/logcat/logcat-service.js
+++ b/res/app/components/stf/logcat/logcat-service.js
@@ -101,6 +101,34 @@ module.exports = function LogcatServiceFactory(socket, FilterStringService) {
     }
   }
 
+  function filterLine(line) {
+    var matched = true
+    var devSerial = line.serial
+    var filters = service.deviceEntries[devSerial].filters
+
+    if (typeof filters !== 'undefined') {
+      if (!_.isEmpty(filters.priority.toString())) {
+        matched &= line.priority >= filters.priority
+      }
+      if (!_.isEmpty(filters.date)) {
+        matched &= FilterStringService.filterString(filters.date, line.dateLabel)
+      }
+      if (!_.isEmpty(filters.pid)) {
+        matched &= FilterStringService.filterInteger(filters.pid, line.pid)
+      }
+      if (!_.isEmpty(filters.tid)) {
+        matched &= FilterStringService.filterInteger(filters.tid, line.tid)
+      }
+      if (!_.isEmpty(filters.tag)) {
+        matched &= FilterStringService.filterString(filters.tag, line.tag)
+      }
+      if (!_.isEmpty(filters.message)) {
+        matched &= FilterStringService.filterString(filters.message, line.message)
+      }
+    }
+    return matched
+  }
+
   socket.on('logcat.entry', function(rawData) {
     deviceSerialExist(rawData.serial)
     var TmpObject = enhanceEntry(rawData)
@@ -135,34 +163,6 @@ module.exports = function LogcatServiceFactory(socket, FilterStringService) {
     if (typeof (service.addFilteredEntriesListener) === 'function') {
       service.addFilteredEntriesListener(service.filters.entries)
     }
-  }
-
-  function filterLine(line) {
-    var matched = true
-    var devSerial = line.serial
-    var filters = service.deviceEntries[devSerial].filters
-
-    if (typeof filters !== 'undefined') {
-      if (!_.isEmpty(filters.priority.toString())) {
-        matched &= line.priority >= filters.priority
-      }
-      if (!_.isEmpty(filters.date)) {
-        matched &= FilterStringService.filterString(filters.date, line.dateLabel)
-      }
-      if (!_.isEmpty(filters.pid)) {
-        matched &= FilterStringService.filterInteger(filters.pid, line.pid)
-      }
-      if (!_.isEmpty(filters.tid)) {
-        matched &= FilterStringService.filterInteger(filters.tid, line.tid)
-      }
-      if (!_.isEmpty(filters.tag)) {
-        matched &= FilterStringService.filterString(filters.tag, line.tag)
-      }
-      if (!_.isEmpty(filters.message)) {
-        matched &= FilterStringService.filterString(filters.message, line.message)
-      }
-    }
-    return matched
   }
 
   return service

--- a/res/app/components/stf/native-url/native-url-service.js
+++ b/res/app/components/stf/native-url/native-url-service.js
@@ -52,7 +52,7 @@ module.exports = function NativeUrlServiceFactory($window, $timeout) {
           if (wasBlured) {
             wasBlured = false
           }
- else {
+          else {
             $window.open(options.webUrl, '_blank')
           }
 

--- a/res/app/components/stf/nav-menu/nav-menu-directive.js
+++ b/res/app/components/stf/nav-menu/nav-menu-directive.js
@@ -25,7 +25,7 @@ module.exports = function($location) {
         if ($location.$$html5) {
           urlMap.push({url: url, link: link})
         }
- else {
+        else {
           urlMap.push({url: url.replace(routePattern, ''), link: link})
         }
       }

--- a/res/app/components/stf/nav-menu/nav-menu-spec.js
+++ b/res/app/components/stf/nav-menu/nav-menu-spec.js
@@ -1,13 +1,6 @@
 describe('navMenu', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/screen/fast-image-render/index.js
+++ b/res/app/components/stf/screen/fast-image-render/index.js
@@ -40,7 +40,7 @@ function FastImageRender(canvasElement, options) {
     var WebGLRender = require('./webgl-render').WebGLRender
     this.render = new WebGLRender(canvasElement, options)
   }
- else {
+  else {
     var CanvasRender = require('./canvas-render').CanvasRender
     this.render = new CanvasRender(canvasElement, options)
   }
@@ -76,7 +76,7 @@ FastImageRender.prototype.load = function(url, type) {
         }
       }, type)
     }
- else {
+    else {
       this.textureLoader.load(url, function(texture) {
         if (typeof (that.onLoad) === 'function') {
           that.onLoad(texture)
@@ -84,7 +84,7 @@ FastImageRender.prototype.load = function(url, type) {
       })
     }
   }
- else {
+  else {
     this.loader.src = url
   }
 }

--- a/res/app/components/stf/screen/fast-image-render/test/performance_test.js
+++ b/res/app/components/stf/screen/fast-image-render/test/performance_test.js
@@ -48,7 +48,7 @@ imageRender.onLoad = function(image) {
   if (frame.current++ < frame.total) {
     loadNext()
   }
- else {
+  else {
     var endTime = new Date().getTime()
     var totalTime = endTime - startTime
     totalTimeElement.innerHTML = totalTime / 1000 + ' seconds'

--- a/res/app/components/stf/screen/fast-image-render/webgl-render.js
+++ b/res/app/components/stf/screen/fast-image-render/webgl-render.js
@@ -223,11 +223,11 @@ function WebGLRender(canvasElement) {
   try {
     this.ctx = canvasElement.getContext('experimental-webgl', this.options)
   }
- catch (e) {
+  catch (e) {
     try {
       this.ctx = canvasElement.getContext('webgl', this.options)
     }
- catch (e2) {
+    catch (e2) {
       // fail, not able to get a context
       throw new Error('This browser does not support webGL. Try using the' +
       'canvas renderer' + this)
@@ -323,6 +323,7 @@ WebGLRender.prototype.drawOld = function(image) {
   this.ctx.texParameteri(
     this.ctx.TEXTURE_2D, this.ctx.TEXTURE_MAG_FILTER, this.ctx.NEAREST
   )
+
   /*
    this.ctx.texParameteri(
    this.ctx.TEXTURE_2D

--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -49,6 +49,8 @@ module.exports = function DeviceScreenDirective(
        * This section should deal with updating the screen ONLY.
        */
       ;(function() {
+        var ws, adjustedBoundSize
+
         function stop() {
           try {
             ws.onerror = ws.onclose = ws.onmessage = ws.onopen = null
@@ -58,7 +60,7 @@ module.exports = function DeviceScreenDirective(
           catch (err) { /* noop */ }
         }
 
-        var ws = new WebSocket(device.display.url)
+        ws = new WebSocket(device.display.url)
         ws.binaryType = 'blob'
 
         ws.onerror = function errorListener() {
@@ -67,10 +69,6 @@ module.exports = function DeviceScreenDirective(
 
         ws.onclose = function closeListener() {
           // @todo Maybe handle
-        }
-
-        ws.onopen = function openListener() {
-          checkEnabled()
         }
 
         var canvas = element.find('canvas')[0]
@@ -95,8 +93,13 @@ module.exports = function DeviceScreenDirective(
         , minscale: 0.36
         }
 
-        var adjustedBoundSize
         var cachedEnabled = false
+
+        function onScreenInterestAreaChanged() {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send('size ' + adjustedBoundSize.w + 'x' + adjustedBoundSize.h)
+          }
+        }
 
         function updateBounds() {
           function adjustBoundedSize(w, h) {
@@ -138,7 +141,7 @@ module.exports = function DeviceScreenDirective(
               return adjustBoundedSize(h, w)
             case 0:
             case 180:
-              /* falls through */
+              // falls through
             default:
               return adjustBoundedSize(w, h)
             }
@@ -166,6 +169,19 @@ module.exports = function DeviceScreenDirective(
           )
         }
 
+        function onScreenInterestGained() {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send('size ' + adjustedBoundSize.w + 'x' + adjustedBoundSize.h)
+            ws.send('on')
+          }
+        }
+
+        function onScreenInterestLost() {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send('off')
+          }
+        }
+
         function checkEnabled() {
           var newEnabled = shouldUpdateScreen()
 
@@ -184,23 +200,16 @@ module.exports = function DeviceScreenDirective(
           cachedEnabled = newEnabled
         }
 
-        function onScreenInterestGained() {
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.send('size ' + adjustedBoundSize.w + 'x' + adjustedBoundSize.h)
-            ws.send('on')
-          }
+        ws.onopen = function openListener() {
+          checkEnabled()
         }
 
-        function onScreenInterestAreaChanged() {
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.send('size ' + adjustedBoundSize.w + 'x' + adjustedBoundSize.h)
-          }
-        }
+        var canvasAspect = 1
+        var parentAspect = 1
 
-        function onScreenInterestLost() {
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.send('off')
-          }
+        function maybeFlipLetterbox() {
+          element[0].classList.toggle(
+            'letterboxed', parentAspect < canvasAspect)
         }
 
         ws.onmessage = (function() {
@@ -300,6 +309,7 @@ module.exports = function DeviceScreenDirective(
                 })
 
                 var img = imagePool.next()
+                var url = URL.createObjectURL(blob)
 
                 img.onload = function() {
                   updateImageArea(this)
@@ -335,7 +345,6 @@ module.exports = function DeviceScreenDirective(
                   url = null
                 }
 
-                var url = URL.createObjectURL(blob)
                 img.src = url
               }
             }
@@ -370,17 +379,10 @@ module.exports = function DeviceScreenDirective(
           control.rotate(90)
         })
 
-        var canvasAspect = 1
-        var parentAspect = 1
 
         function resizeListener() {
           parentAspect = element[0].offsetWidth / element[0].offsetHeight
           maybeFlipLetterbox()
-        }
-
-        function maybeFlipLetterbox() {
-          element[0].classList.toggle(
-            'letterboxed', parentAspect < canvasAspect)
         }
 
         $window.addEventListener('resize', resizeListener, false)
@@ -522,6 +524,12 @@ module.exports = function DeviceScreenDirective(
           return ++seq >= cycle ? (seq = 0) : seq
         }
 
+        function createFinger(index) {
+          var el = document.createElement('span')
+          el.className = 'finger finger-' + index
+          return el
+        }
+
         function createSlots() {
           // The reverse order is important because slots and fingers are in
           // opposite sort order. Anyway don't change anything here unless
@@ -552,12 +560,6 @@ module.exports = function DeviceScreenDirective(
           }
         }
 
-        function createFinger(index) {
-          var el = document.createElement('span')
-          el.className = 'finger finger-' + index
-          return el
-        }
-
         function calculateBounds() {
           var el = element[0]
 
@@ -570,66 +572,6 @@ module.exports = function DeviceScreenDirective(
             screen.bounds.x += el.offsetLeft
             screen.bounds.y += el.offsetTop
             el = el.offsetParent
-          }
-        }
-
-        function mouseDownListener(event) {
-          var e = event
-          if (e.originalEvent) {
-            e = e.originalEvent
-          }
-
-          // Skip secondary click
-          if (e.which === 3) {
-            return
-          }
-
-          e.preventDefault()
-
-          fakePinch = e.altKey
-
-          calculateBounds()
-          startMousing()
-
-          var x = e.pageX - screen.bounds.x
-          var y = e.pageY - screen.bounds.y
-          var pressure = 0.5
-          var scaled = scaler.coords(
-                screen.bounds.w
-              , screen.bounds.h
-              , x
-              , y
-              , screen.rotation
-              )
-
-          control.touchDown(nextSeq(), 0, scaled.xP, scaled.yP, pressure)
-
-          if (fakePinch) {
-            control.touchDown(nextSeq(), 1, 1 - scaled.xP, 1 - scaled.yP,
-              pressure)
-          }
-
-          control.touchCommit(nextSeq())
-
-          activateFinger(0, x, y, pressure)
-
-          if (fakePinch) {
-            activateFinger(1, -e.pageX + screen.bounds.x + screen.bounds.w,
-              -e.pageY + screen.bounds.y + screen.bounds.h, pressure)
-          }
-
-          element.bind('mousemove', mouseMoveListener)
-          $document.bind('mouseup', mouseUpListener)
-          $document.bind('mouseleave', mouseUpListener)
-
-          if (lastPossiblyBuggyMouseUpEvent &&
-              lastPossiblyBuggyMouseUpEvent.timeStamp > e.timeStamp) {
-            // We got mouseup before mousedown. See mouseUpBugWorkaroundListener
-            // for details.
-            mouseUpListener(lastPossiblyBuggyMouseUpEvent)
-          }
-          else {
-            lastPossiblyBuggyMouseUpEvent = null
           }
         }
 
@@ -712,7 +654,82 @@ module.exports = function DeviceScreenDirective(
             deactivateFinger(1)
           }
 
+          // mutual reference: stopMousing unbinds this listener
+          // eslint-disable-next-line no-use-before-define
           stopMousing()
+        }
+
+        function stopMousing() {
+          element.unbind('mousemove', mouseMoveListener)
+          $document.unbind('mouseup', mouseUpListener)
+          $document.unbind('mouseleave', mouseUpListener)
+          deactivateFingers()
+          control.gestureStop(nextSeq())
+        }
+
+        function startMousing() {
+          control.gestureStart(nextSeq())
+          input[0].focus()
+        }
+
+        function mouseDownListener(event) {
+          var e = event
+          if (e.originalEvent) {
+            e = e.originalEvent
+          }
+
+          // Skip secondary click
+          if (e.which === 3) {
+            return
+          }
+
+          e.preventDefault()
+
+          fakePinch = e.altKey
+
+          calculateBounds()
+          startMousing()
+
+          var x = e.pageX - screen.bounds.x
+          var y = e.pageY - screen.bounds.y
+          var pressure = 0.5
+          var scaled = scaler.coords(
+                screen.bounds.w
+              , screen.bounds.h
+              , x
+              , y
+              , screen.rotation
+              )
+
+          control.touchDown(nextSeq(), 0, scaled.xP, scaled.yP, pressure)
+
+          if (fakePinch) {
+            control.touchDown(nextSeq(), 1, 1 - scaled.xP, 1 - scaled.yP,
+              pressure)
+          }
+
+          control.touchCommit(nextSeq())
+
+          activateFinger(0, x, y, pressure)
+
+          if (fakePinch) {
+            activateFinger(1, -e.pageX + screen.bounds.x + screen.bounds.w,
+              -e.pageY + screen.bounds.y + screen.bounds.h, pressure)
+          }
+
+          element.bind('mousemove', mouseMoveListener)
+          $document.bind('mouseup', mouseUpListener)
+          $document.bind('mouseleave', mouseUpListener)
+
+          if (lastPossiblyBuggyMouseUpEvent &&
+              lastPossiblyBuggyMouseUpEvent.timeStamp > e.timeStamp) {
+            // We got mouseup before mousedown. See mouseUpBugWorkaroundListener
+            // for details.
+            mouseUpListener(lastPossiblyBuggyMouseUpEvent)
+          }
+          else {
+            lastPossiblyBuggyMouseUpEvent = null
+          }
         }
 
         /*
@@ -770,17 +787,77 @@ module.exports = function DeviceScreenDirective(
           lastPossiblyBuggyMouseUpEvent = e
         }
 
-        function startMousing() {
-          control.gestureStart(nextSeq())
-          input[0].focus()
+        function touchMoveListener(event) {
+          var e = event
+          e.preventDefault()
+
+          if (e.originalEvent) {
+            e = e.originalEvent
+          }
+
+          for (var i = 0, l = e.changedTouches.length; i < l; ++i) {
+            var touch = e.changedTouches[i]
+            var slot = slotted[touch.identifier]
+            var x = touch.pageX - screen.bounds.x
+            var y = touch.pageY - screen.bounds.y
+            var pressure = touch.force || 0.5
+            var scaled = scaler.coords(
+                  screen.bounds.w
+                , screen.bounds.h
+                , x
+                , y
+                , screen.rotation
+                )
+
+            control.touchMove(nextSeq(), slot, scaled.xP, scaled.yP, pressure)
+            activateFinger(slot, x, y, pressure)
+          }
+
+          control.touchCommit(nextSeq())
         }
 
-        function stopMousing() {
-          element.unbind('mousemove', mouseMoveListener)
-          $document.unbind('mouseup', mouseUpListener)
-          $document.unbind('mouseleave', mouseUpListener)
+        function touchEndListener(event) {
+          var e = event
+          if (e.originalEvent) {
+            e = e.originalEvent
+          }
+
+          var foundAny = false
+
+          for (var i = 0, l = e.changedTouches.length; i < l; ++i) {
+            var touch = e.changedTouches[i]
+            var slot = slotted[touch.identifier]
+            // A missing slot means we already disposed of the contact. We may
+            // have gotten a touchend event for the same contact twice.
+            if (typeof slot !== 'undefined') {
+              delete slotted[touch.identifier]
+              slots.push(slot)
+              control.touchUp(nextSeq(), slot)
+              deactivateFinger(slot)
+              foundAny = true
+            }
+          }
+
+          if (foundAny) {
+            control.touchCommit(nextSeq())
+            if (!e.touches.length) {
+              // mutual reference: stopTouching unbinds this listener
+              // eslint-disable-next-line no-use-before-define
+              stopTouching()
+            }
+          }
+        }
+
+        function stopTouching() {
+          element.unbind('touchmove', touchMoveListener)
+          $document.unbind('touchend', touchEndListener)
+          $document.unbind('touchleave', touchEndListener)
           deactivateFingers()
           control.gestureStop(nextSeq())
+        }
+
+        function startTouching() {
+          control.gestureStart(nextSeq())
         }
 
         function touchStartListener(event) {
@@ -851,77 +928,6 @@ module.exports = function DeviceScreenDirective(
           $document.bind('touchleave', touchEndListener)
 
           control.touchCommit(nextSeq())
-        }
-
-        function touchMoveListener(event) {
-          var e = event
-          e.preventDefault()
-
-          if (e.originalEvent) {
-            e = e.originalEvent
-          }
-
-          for (var i = 0, l = e.changedTouches.length; i < l; ++i) {
-            var touch = e.changedTouches[i]
-            var slot = slotted[touch.identifier]
-            var x = touch.pageX - screen.bounds.x
-            var y = touch.pageY - screen.bounds.y
-            var pressure = touch.force || 0.5
-            var scaled = scaler.coords(
-                  screen.bounds.w
-                , screen.bounds.h
-                , x
-                , y
-                , screen.rotation
-                )
-
-            control.touchMove(nextSeq(), slot, scaled.xP, scaled.yP, pressure)
-            activateFinger(slot, x, y, pressure)
-          }
-
-          control.touchCommit(nextSeq())
-        }
-
-        function touchEndListener(event) {
-          var e = event
-          if (e.originalEvent) {
-            e = e.originalEvent
-          }
-
-          var foundAny = false
-
-          for (var i = 0, l = e.changedTouches.length; i < l; ++i) {
-            var touch = e.changedTouches[i]
-            var slot = slotted[touch.identifier]
-            // A missing slot means we already disposed of the contact. We may
-            // have gotten a touchend event for the same contact twice.
-            if (typeof slot !== 'undefined') {
-              delete slotted[touch.identifier]
-              slots.push(slot)
-              control.touchUp(nextSeq(), slot)
-              deactivateFinger(slot)
-              foundAny = true
-            }
-          }
-
-          if (foundAny) {
-            control.touchCommit(nextSeq())
-            if (!e.touches.length) {
-              stopTouching()
-            }
-          }
-        }
-
-        function startTouching() {
-          control.gestureStart(nextSeq())
-        }
-
-        function stopTouching() {
-          element.unbind('touchmove', touchMoveListener)
-          $document.unbind('touchend', touchEndListener)
-          $document.unbind('touchleave', touchEndListener)
-          deactivateFingers()
-          control.gestureStop(nextSeq())
         }
 
         element.on('touchstart', touchStartListener)

--- a/res/app/components/stf/screen/screen-keyboard/screen-keyboard-spec.js
+++ b/res/app/components/stf/screen/screen-keyboard/screen-keyboard-spec.js
@@ -1,13 +1,6 @@
 describe('screenKeyboard', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/screen/screen-touch/screen-touch-spec.js
+++ b/res/app/components/stf/screen/screen-touch/screen-touch-spec.js
@@ -1,13 +1,6 @@
 describe('screenTouch', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/socket/socket-state/index.js
+++ b/res/app/components/stf/socket/socket-state/index.js
@@ -17,7 +17,7 @@ module.exports = angular.module('stf/socket/socket-state', [
                 fn()
               }
             }
- else {
+            else {
               $delegate.$apply(fn)
             }
           }

--- a/res/app/components/stf/text-history/text-history-spec.js
+++ b/res/app/components/stf/text-history/text-history-spec.js
@@ -1,13 +1,6 @@
 describe('textHistory', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/timelines/timeline-message/timeline-message-spec.js
+++ b/res/app/components/stf/timelines/timeline-message/timeline-message-spec.js
@@ -1,13 +1,6 @@
 describe('timelineMessage', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/timelines/timelines-spec.js
+++ b/res/app/components/stf/timelines/timelines-spec.js
@@ -1,13 +1,6 @@
 describe('timelines', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, compile
-
-  beforeEach(inject(function($rootScope, $compile) {
-    scope = $rootScope.$new()
-    compile = $compile
-  }))
-
   it('should ...', function() {
 
     /*

--- a/res/app/components/stf/transaction/transaction-service.js
+++ b/res/app/components/stf/transaction/transaction-service.js
@@ -8,103 +8,6 @@ module.exports = function TransactionServiceFactory(socket, TransactionError) {
     return 'tx.' + uuid.v4()
   }
 
-  function MultiTargetTransaction(targets, options) {
-    var pending = Object.create(null)
-    var results = []
-    var channel = createChannel()
-
-    function doneListener(someChannel, data) {
-      if (someChannel === channel) {
-        pending[data.source].done(data)
-      }
-    }
-
-    function progressListener(someChannel, data) {
-      if (someChannel === channel) {
-        pending[data.source].progress(data)
-      }
-    }
-
-    function cancelListener(someChannel, data) {
-      if (someChannel === channel) {
-        Object.keys(pending).forEach(function(source) {
-          pending[source].cancel(data)
-        })
-      }
-    }
-
-    socket.on('tx.done', doneListener)
-    socket.on('tx.progress', progressListener)
-    socket.on('tx.cancel', cancelListener)
-
-    this.channel = channel
-    this.results = results
-    this.promise = Promise.settle(targets.map(function(target) {
-        var result = new options.result(target)
-        var pendingResult = new PendingTransactionResult(result)
-        pending[options.id ? target[options.id] : target.id] = pendingResult
-        results.push(result)
-        return pendingResult.promise
-      }))
-      .finally(function() {
-        socket.removeListener('tx.done', doneListener)
-        socket.removeListener('tx.progress', progressListener)
-        socket.removeListener('tx.cancel', cancelListener)
-        socket.emit('tx.cleanup', channel)
-      })
-      .progressed(function() {
-        return results
-      })
-      .then(function() {
-        return results
-      })
-  }
-
-  function SingleTargetTransaction(target, options) {
-    var result = new options.result(target)
-    var pending = new PendingTransactionResult(result)
-    var channel = createChannel()
-
-    function doneListener(someChannel, data) {
-      if (someChannel === channel) {
-        pending.done(data)
-      }
-    }
-
-    function progressListener(someChannel, data) {
-      if (someChannel === channel) {
-        pending.progress(data)
-      }
-    }
-
-    function cancelListener(someChannel, data) {
-      if (someChannel === channel) {
-        pending.cancel(data)
-      }
-    }
-
-    socket.on('tx.done', doneListener)
-    socket.on('tx.progress', progressListener)
-    socket.on('tx.cancel', cancelListener)
-
-    this.channel = channel
-    this.result = result
-    this.results = [result]
-    this.promise = pending.promise
-      .finally(function() {
-        socket.removeListener('tx.done', doneListener)
-        socket.removeListener('tx.progress', progressListener)
-        socket.removeListener('tx.cancel', cancelListener)
-        socket.emit('tx.cleanup', channel)
-      })
-      .progressed(function() {
-        return result
-      })
-      .then(function() {
-        return result
-      })
-  }
-
   function PendingTransactionResult(result) {
     var resolver = Promise.defer()
     var seq = 0
@@ -179,6 +82,103 @@ module.exports = function TransactionServiceFactory(socket, TransactionError) {
     })
   }
 
+  function MultiTargetTransaction(targets, options) {
+    var pending = Object.create(null)
+    var results = []
+    var channel = createChannel()
+
+    function doneListener(someChannel, data) {
+      if (someChannel === channel) {
+        pending[data.source].done(data)
+      }
+    }
+
+    function progressListener(someChannel, data) {
+      if (someChannel === channel) {
+        pending[data.source].progress(data)
+      }
+    }
+
+    function cancelListener(someChannel, data) {
+      if (someChannel === channel) {
+        Object.keys(pending).forEach(function(source) {
+          pending[source].cancel(data)
+        })
+      }
+    }
+
+    socket.on('tx.done', doneListener)
+    socket.on('tx.progress', progressListener)
+    socket.on('tx.cancel', cancelListener)
+
+    this.channel = channel
+    this.results = results
+    this.promise = Promise.settle(targets.map(function(target) {
+        var result = new options.Result(target)
+        var pendingResult = new PendingTransactionResult(result)
+        pending[options.id ? target[options.id] : target.id] = pendingResult
+        results.push(result)
+        return pendingResult.promise
+      }))
+      .finally(function() {
+        socket.removeListener('tx.done', doneListener)
+        socket.removeListener('tx.progress', progressListener)
+        socket.removeListener('tx.cancel', cancelListener)
+        socket.emit('tx.cleanup', channel)
+      })
+      .progressed(function() {
+        return results
+      })
+      .then(function() {
+        return results
+      })
+  }
+
+  function SingleTargetTransaction(target, options) {
+    var result = new options.Result(target)
+    var pending = new PendingTransactionResult(result)
+    var channel = createChannel()
+
+    function doneListener(someChannel, data) {
+      if (someChannel === channel) {
+        pending.done(data)
+      }
+    }
+
+    function progressListener(someChannel, data) {
+      if (someChannel === channel) {
+        pending.progress(data)
+      }
+    }
+
+    function cancelListener(someChannel, data) {
+      if (someChannel === channel) {
+        pending.cancel(data)
+      }
+    }
+
+    socket.on('tx.done', doneListener)
+    socket.on('tx.progress', progressListener)
+    socket.on('tx.cancel', cancelListener)
+
+    this.channel = channel
+    this.result = result
+    this.results = [result]
+    this.promise = pending.promise
+      .finally(function() {
+        socket.removeListener('tx.done', doneListener)
+        socket.removeListener('tx.progress', progressListener)
+        socket.removeListener('tx.cancel', cancelListener)
+        socket.emit('tx.cleanup', channel)
+      })
+      .progressed(function() {
+        return result
+      })
+      .then(function() {
+        return result
+      })
+  }
+
   function TransactionResult(source) {
     this.source = source
     this.settled = false
@@ -199,19 +199,19 @@ module.exports = function TransactionServiceFactory(socket, TransactionError) {
   DeviceTransactionResult.constructor = DeviceTransactionResult
 
   transactionService.create = function(target, options) {
-    if (options && !options.result) {
-      options.result = TransactionResult
+    if (options && !options.Result) {
+      options.Result = TransactionResult
     }
 
     if (Array.isArray(target)) {
       return new MultiTargetTransaction(target, options || {
-        result: DeviceTransactionResult
+        Result: DeviceTransactionResult
       , id: 'serial'
       })
     }
     else {
       return new SingleTargetTransaction(target, options || {
-        result: DeviceTransactionResult
+        Result: DeviceTransactionResult
       , id: 'serial'
       })
     }

--- a/res/app/control-panes/activity/activity-controller.js
+++ b/res/app/control-panes/activity/activity-controller.js
@@ -10,7 +10,7 @@ module.exports = function ActivityCtrl($scope, gettext, TimelineService) {
         title = newValue
         message = 'Device is now ' + newValue
       }
- else {
+      else {
         title = newValue
         message = '!Device is now ' + newValue
       }

--- a/res/app/control-panes/activity/activity-spec.js
+++ b/res/app/control-panes/activity/activity-spec.js
@@ -1,11 +1,11 @@
 describe('ActivityCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('ActivityCtrl', {$scope: scope})
+    $controller('ActivityCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/advanced/advanced-spec.js
+++ b/res/app/control-panes/advanced/advanced-spec.js
@@ -1,11 +1,11 @@
 describe('AdvancedCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('AdvancedCtrl', {$scope: scope})
+    $controller('AdvancedCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/advanced/input/input-spec.js
+++ b/res/app/control-panes/advanced/input/input-spec.js
@@ -1,11 +1,11 @@
 describe('InputAdvancedCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('InputAdvancedCtrl', {$scope: scope})
+    $controller('InputAdvancedCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/advanced/maintenance/maintenance-spec.js
+++ b/res/app/control-panes/advanced/maintenance/maintenance-spec.js
@@ -1,11 +1,11 @@
 describe('MaintenanceCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('MaintenanceCtrl', {$scope: scope})
+    $controller('MaintenanceCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/advanced/port-forwarding/port-forwarding-spec.js
+++ b/res/app/control-panes/advanced/port-forwarding/port-forwarding-spec.js
@@ -1,11 +1,11 @@
 describe('PortForwardingCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('PortForwardingCtrl', {$scope: scope})
+    $controller('PortForwardingCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/advanced/run-js/run-js-spec.js
+++ b/res/app/control-panes/advanced/run-js/run-js-spec.js
@@ -1,11 +1,11 @@
 describe('RunJsCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('RunJsCtrl', {$scope: scope})
+    $controller('RunJsCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/advanced/usb/usb-spec.js
+++ b/res/app/control-panes/advanced/usb/usb-spec.js
@@ -1,11 +1,11 @@
 describe('UsbCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('UsbCtrl', {$scope: scope})
+    $controller('UsbCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/advanced/vnc/vnc-spec.js
+++ b/res/app/control-panes/advanced/vnc/vnc-spec.js
@@ -1,11 +1,11 @@
 describe('VNCCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('VNCCtrl', {$scope: scope})
+    $controller('VNCCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/automation/device-settings/device-settings-spec.js
+++ b/res/app/control-panes/automation/device-settings/device-settings-spec.js
@@ -1,11 +1,11 @@
 describe('DeviceSettingsCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('DeviceSettingsCtrl', {$scope: scope})
+    $controller('DeviceSettingsCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/automation/store-account/store-account-controller.js
+++ b/res/app/control-panes/automation/store-account/store-account-controller.js
@@ -11,6 +11,17 @@ module.exports = function StoreAccountCtrl($scope, $timeout) {
 
   $scope.addingAccount = false
 
+  function getAccounts() {
+    var storeAccountType = $scope.deviceAppStores[$scope.currentAppStore].package
+    if ($scope.control) {
+      $scope.control.getAccounts(storeAccountType).then(function(result) {
+        $scope.$apply(function() {
+          $scope.accountsList = result.body
+        })
+      })
+    }
+  }
+
   $scope.addAccount = function() {
     $scope.addingAccount = true
     var user = $scope.storeLogin.username.$modelValue
@@ -36,17 +47,6 @@ module.exports = function StoreAccountCtrl($scope, $timeout) {
       .catch(function(result) {
         throw new Error('Removing account failed', result)
       })
-  }
-
-  function getAccounts() {
-    var storeAccountType = $scope.deviceAppStores[$scope.currentAppStore].package
-    if ($scope.control) {
-      $scope.control.getAccounts(storeAccountType).then(function(result) {
-        $scope.$apply(function() {
-          $scope.accountsList = result.body
-        })
-      })
-    }
   }
 
   getAccounts()

--- a/res/app/control-panes/automation/store-account/store-account-spec.js
+++ b/res/app/control-panes/automation/store-account/store-account-spec.js
@@ -1,11 +1,11 @@
 describe('StoreAccountCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('StoreAccountCtrl', {$scope: scope})
+    $controller('StoreAccountCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/control-panes-hotkeys-controller.js
+++ b/res/app/control-panes/control-panes-hotkeys-controller.js
@@ -25,7 +25,7 @@ module.exports =
         if (angle === 0) {
           angle = 270
         }
- else {
+        else {
           angle -= 90
         }
         $scope.control.rotate(angle)
@@ -42,7 +42,7 @@ module.exports =
         if (angle === 270) {
           angle = 0
         }
- else {
+        else {
           angle += 90
         }
         $scope.control.rotate(angle)
@@ -78,7 +78,7 @@ module.exports =
         if ($rootScope.platform === 'web') {
           $rootScope.platform = 'native'
         }
- else {
+        else {
           $rootScope.platform = 'web'
         }
       }

--- a/res/app/control-panes/control-panes-no-device-controller.js
+++ b/res/app/control-panes/control-panes-no-device-controller.js
@@ -5,7 +5,7 @@ module.exports =
     if (lastUsedDevice) {
       $location.path('/control/' + lastUsedDevice)
     }
- else {
+    else {
       $location.path('/')
     }
   }

--- a/res/app/control-panes/cpu/cpu-spec.js
+++ b/res/app/control-panes/cpu/cpu-spec.js
@@ -1,11 +1,11 @@
 describe('CpuCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('CpuCtrl', {$scope: scope})
+    $controller('CpuCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/dashboard/apps/apps-controller.js
+++ b/res/app/control-panes/dashboard/apps/apps-controller.js
@@ -8,7 +8,7 @@ module.exports = function ShellCtrl($scope) {
     // Force run activity
     command += ' --activity-clear-top'
     return $scope.control.shell(command)
-      .then(function(result) {
+      .then(function() {
         // console.log(result)
       })
   }

--- a/res/app/control-panes/dashboard/clipboard/clipboard-spec.js
+++ b/res/app/control-panes/dashboard/clipboard/clipboard-spec.js
@@ -1,11 +1,11 @@
 describe('ClipboardCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('ClipboardCtrl', {$scope: scope})
+    $controller('ClipboardCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/dashboard/dashboard-spec.js
+++ b/res/app/control-panes/dashboard/dashboard-spec.js
@@ -1,11 +1,11 @@
 describe('DashboardCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('DashboardCtrl', {$scope: scope})
+    $controller('DashboardCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/dashboard/install/activities/activities-controller.js
+++ b/res/app/control-panes/dashboard/install/activities/activities-controller.js
@@ -52,10 +52,10 @@ module.exports = function ActivitiesCtrl($scope) {
               if (data.path) {
                 uri += '/' + data.path
               }
- else if (data.pathPrefix) {
+              else if (data.pathPrefix) {
                 uri += '/' + data.pathPrefix
               }
- else if (data.pathPattern) {
+              else if (data.pathPattern) {
                 uri += '/' + data.pathPattern
               }
               activityData.push(uri)
@@ -90,7 +90,7 @@ module.exports = function ActivitiesCtrl($scope) {
     }
 
     return $scope.control.shell(command)
-      .then(function(result) {
+      .then(function() {
         // console.log(result)
       })
   }

--- a/res/app/control-panes/dashboard/install/activities/activities-spec.js
+++ b/res/app/control-panes/dashboard/install/activities/activities-spec.js
@@ -1,11 +1,11 @@
 describe('ActivitiesCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('ActivitiesCtrl', {$scope: scope})
+    $controller('ActivitiesCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/dashboard/install/install-spec.js
+++ b/res/app/control-panes/dashboard/install/install-spec.js
@@ -1,11 +1,11 @@
 describe('InstallCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('InstallCtrl', {$scope: scope})
+    $controller('InstallCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/dashboard/navigation/navigation-controller.js
+++ b/res/app/control-panes/dashboard/navigation/navigation-controller.js
@@ -54,12 +54,12 @@ module.exports = function NavigationCtrl($scope, $rootScope) {
           currentBrowser = selectedBrowser
         }
       }
- else {
+      else {
         var defaultBrowser = _.find(browser.apps, {name: 'Browser'})
         if (defaultBrowser) {
           currentBrowser = defaultBrowser
         }
- else {
+        else {
           currentBrowser = _.head(browser.apps)
         }
       }

--- a/res/app/control-panes/dashboard/navigation/navigation-spec.js
+++ b/res/app/control-panes/dashboard/navigation/navigation-spec.js
@@ -1,11 +1,11 @@
 describe('NavigationCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('NavigationCtrl', {$scope: scope})
+    $controller('NavigationCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/dashboard/remote-debug/remote-debug-controller.js
+++ b/res/app/control-panes/dashboard/remote-debug/remote-debug-controller.js
@@ -27,7 +27,7 @@ module.exports = function RemoteDebugCtrl($scope, $timeout, gettext) {
       $scope.remoteDebugTooltip =
         gettext('Run the following on your command line to debug the device from your IDE')
     }
- else {
+    else {
       $scope.remoteDebugTooltip =
         gettext('Run the following on your command line to debug the device from your Browser')
     }

--- a/res/app/control-panes/dashboard/remote-debug/remote-debug-spec.js
+++ b/res/app/control-panes/dashboard/remote-debug/remote-debug-spec.js
@@ -1,11 +1,11 @@
 describe('RemoteDebugCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('RemoteDebugCtrl', {$scope: scope})
+    $controller('RemoteDebugCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/dashboard/shell/shell-spec.js
+++ b/res/app/control-panes/dashboard/shell/shell-spec.js
@@ -1,11 +1,11 @@
 describe('ShellCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('ShellCtrl', {$scope: scope})
+    $controller('ShellCtrl', {$scope: scope})
   }))
 
   it('should clear the results', inject(function() {

--- a/res/app/control-panes/device-control/device-control-controller.js
+++ b/res/app/control-panes/device-control/device-control-controller.js
@@ -8,7 +8,7 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
 
   $scope.groupDevices = $scope.groupTracker.devices
 
-  $scope.$on('$locationChangeStart', function(event, next, current) {
+  $scope.$on('$locationChangeStart', function() {
     $scope.LogcatService = LogcatService
     $rootScope.LogcatService = LogcatService
   })
@@ -43,7 +43,7 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
             $scope.$digest()
           })
         }
- else {
+        else {
           // Kick the device
           GroupService.kick(device).then(function() {
             $scope.$digest()
@@ -51,13 +51,13 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
           $location.path('/devices/')
         }
       }
- else {
+      else {
         GroupService.kick(device).then(function() {
           $scope.$digest()
         })
       }
     }
- catch (e) {
+    catch (e) {
       // eslint-disable-next-line no-alert
       alert(e.message)
     }
@@ -92,7 +92,7 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
         }
       }, 400)
     }
- else if (rotation === 'landscape') {
+    else if (rotation === 'landscape') {
       $scope.control.rotate(90)
       $timeout(function() {
         if (isPortrait()) {
@@ -108,7 +108,7 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
     if (isPortrait(newValue)) {
       $scope.currentRotation = 'portrait'
     }
- else if (isLandscape(newValue)) {
+    else if (isLandscape(newValue)) {
       $scope.currentRotation = 'landscape'
     }
   })
@@ -122,7 +122,7 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
     if (angle === 0) {
       angle = 270
     }
- else {
+    else {
       angle -= 90
     }
     $scope.control.rotate(angle)
@@ -140,7 +140,7 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
     if (angle === 270) {
       angle = 0
     }
- else {
+    else {
       angle += 90
     }
     $scope.control.rotate(angle)

--- a/res/app/control-panes/explorer/explorer-spec.js
+++ b/res/app/control-panes/explorer/explorer-spec.js
@@ -1,7 +1,7 @@
 describe('FsCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller, $q) {
     scope = $rootScope.$new()
@@ -12,7 +12,7 @@ describe('FsCtrl', function() {
         return $q.resolve({body: []})
       }
     }
-    ctrl = $controller('ExplorerCtrl', {$scope: scope})
+    $controller('ExplorerCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/explorer/index.js
+++ b/res/app/control-panes/explorer/index.js
@@ -20,7 +20,7 @@ module.exports = angular.module('stf.explorer', [])
             if ((mode >> (i * 3 + j)) & 1 !== 0) {
               res.unshift(s[j])
             }
- else {
+            else {
               res.unshift('-')
             }
           }
@@ -28,10 +28,10 @@ module.exports = angular.module('stf.explorer', [])
         if ((mode & S_IFMT) === S_IFDIR) {
           res.unshift('d')
         }
- else if ((mode & S_IFMT) === S_IFLNK) {
+        else if ((mode & S_IFMT) === S_IFLNK) {
           res.unshift('l')
         }
- else {
+        else {
           res.unshift('-')
         }
         return res.join('')
@@ -55,10 +55,10 @@ module.exports = angular.module('stf.explorer', [])
       if (size < 1024) {
         formattedSize = size + ' B'
       }
- else if (size >= 1024 && size < 1024 * 1024) {
+      else if (size >= 1024 && size < 1024 * 1024) {
         formattedSize = Math.round(size / 1024, 1) + ' Kb'
       }
- else {
+      else {
         formattedSize = Math.round(size / (1024 * 1024), 1) + ' Mb'
       }
       return formattedSize

--- a/res/app/control-panes/info/info-spec.js
+++ b/res/app/control-panes/info/info-spec.js
@@ -1,11 +1,11 @@
 describe('InfoCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('InfoCtrl', {$scope: scope})
+    $controller('InfoCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/inspect/inspect-spec.js
+++ b/res/app/control-panes/inspect/inspect-spec.js
@@ -1,11 +1,11 @@
 describe('InspectCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('InspectCtrl', {$scope: scope})
+    $controller('InspectCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/logs/logs-controller.js
+++ b/res/app/control-panes/logs/logs-controller.js
@@ -1,18 +1,5 @@
 module.exports = function LogsCtrl($scope, $rootScope, $routeParams, LogcatService) {
   var deviceSerial = $routeParams.serial
-  var cleanDevice = (window.location.href).split('/').pop()
-  cleanDeviceSettings()
-
-  $scope.started = checkLogBtnStatus() === null ? false : checkLogBtnStatus()
-  $scope.filters = {}
-
-  $scope.filters.levelNumbers = LogcatService.filters.levelNumbers
-
-  LogcatService.filters.filterLines()
-
-  restoreFilters()
-  setFiltersPriority()
-
   function cleanDeviceSettings() {
     if (Object.keys($rootScope).includes('LogcatService')) {
       LogcatService.deviceEntries = $rootScope.LogcatService.deviceEntries
@@ -33,7 +20,7 @@ module.exports = function LogsCtrl($scope, $rootScope, $routeParams, LogcatServi
       $scope.filters.priority = $scope.filters.levelNumbers[
         LogcatService.deviceEntries[deviceSerial].selectedLogLevel - 2]
     }
- else {
+    else {
       if ($scope.started) {
         $scope.filters.priority = $scope.filters.levelNumbers[0]
       }
@@ -46,7 +33,7 @@ module.exports = function LogsCtrl($scope, $rootScope, $routeParams, LogcatServi
         if ('filter.' + entry !== 'filter.priority') {
           $scope.filters[entry] = LogcatService.deviceEntries[deviceSerial].filters[entry]
         }
- else {
+        else {
           setFiltersPriority()
         }
       })
@@ -63,6 +50,18 @@ module.exports = function LogsCtrl($scope, $rootScope, $routeParams, LogcatServi
     }
     return null
   }
+
+  cleanDeviceSettings()
+
+  $scope.started = checkLogBtnStatus() === null ? false : checkLogBtnStatus()
+  $scope.filters = {}
+
+  $scope.filters.levelNumbers = LogcatService.filters.levelNumbers
+
+  LogcatService.filters.filterLines()
+
+  restoreFilters()
+  setFiltersPriority()
 
   $scope.$watch('started', function(newValue, oldValue) {
     if (!Object.keys(LogcatService.deviceEntries).includes(deviceSerial)) {
@@ -90,7 +89,7 @@ module.exports = function LogsCtrl($scope, $rootScope, $routeParams, LogcatServi
         $scope.device.logs_enabled = true
         setFiltersPriority()
       }
- else {
+      else {
         if (Object.keys(LogcatService.deviceEntries).includes(deviceSerial)) {
           LogcatService.deviceEntries[deviceSerial].started = false
         }

--- a/res/app/control-panes/logs/logs-spec.js
+++ b/res/app/control-panes/logs/logs-spec.js
@@ -1,13 +1,13 @@
 describe('LogsCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
     // The controller only reads $rootScope.LogcatService when the device list
     // has already published it, so leave it unset here.
-    ctrl = $controller('LogsCtrl', {
+    $controller('LogsCtrl', {
       $scope: scope
       // $routeParams comes from ngRoute, which the pane module does not pull
       // in on its own.

--- a/res/app/control-panes/performance/cpu/cpu-spec.js
+++ b/res/app/control-panes/performance/cpu/cpu-spec.js
@@ -1,11 +1,11 @@
 describe('CpuCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('CpuCtrl', {$scope: scope})
+    $controller('CpuCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/performance/performance-spec.js
+++ b/res/app/control-panes/performance/performance-spec.js
@@ -1,11 +1,11 @@
 describe('PerformanceCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('PerformanceCtrl', {$scope: scope})
+    $controller('PerformanceCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/resources/resources-spec.js
+++ b/res/app/control-panes/resources/resources-spec.js
@@ -1,11 +1,11 @@
 describe('ResourcesCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('ResourcesCtrl', {$scope: scope})
+    $controller('ResourcesCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/control-panes/screenshots/screenshots-controller.js
+++ b/res/app/control-panes/screenshots/screenshots-controller.js
@@ -27,7 +27,7 @@ module.exports = function ScreenshotsCtrl($scope) {
     if (param.min && newValue < param.min) {
       newValue = param.min
     }
- else if (param.max && newValue > param.max) {
+    else if (param.max && newValue > param.max) {
       newValue = param.max
     }
     $scope.screenShotSize = newValue

--- a/res/app/control-panes/screenshots/screenshots-spec.js
+++ b/res/app/control-panes/screenshots/screenshots-spec.js
@@ -1,11 +1,11 @@
 describe('ScreenshotsCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('ScreenshotsCtrl', {$scope: scope})
+    $controller('ScreenshotsCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -22,28 +22,426 @@ var filterOps = {
   }
 }
 
+function zeroPadTwoDigit(digit) {
+  return digit < 10 ? '0' + digit : '' + digit
+}
+
+function compareIgnoreCase(a, b) {
+/* **** fix bug: cast to String for Safari compatibility **** */
+  var la = (String(a) || '').toLowerCase()
+  var lb = (String(b) || '').toLowerCase()
+
+/***********************************************************/
+  if (la === lb) {
+    return 0
+  }
+  else {
+    return la < lb ? -1 : 1
+  }
+}
+
+function filterIgnoreCase(a, filterValue) {
+/* **** fix bug: cast to String for Safari compatibility **** */
+  var va = (String(a) || '').toLowerCase()
+  var vb = String(filterValue).toLowerCase()
+
+/***********************************************************/
+  return va.indexOf(vb) !== -1
+}
+
+function compareRespectCase(a, b) {
+  if (a === b) {
+    return 0
+  }
+  else {
+    return a < b ? -1 : 1
+  }
+}
+
+
+function textCell(options) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      td.appendChild(document.createTextNode(''))
+      return td
+    }
+  , update: function(td, item) {
+      var t = td.firstChild
+      t.nodeValue = options.value(item)
+      return td
+    }
+  , compare: function(a, b) {
+      return compareIgnoreCase(options.value(a), options.value(b))
+    }
+  , filter: function(item, filter) {
+      return filterIgnoreCase(options.value(item), filter.query)
+    }
+  })
+}
+
+function numberCell(options) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      td.appendChild(document.createTextNode(''))
+      return td
+    }
+  , update: function(td, item) {
+      var t = td.firstChild
+      t.nodeValue = options.format(options.value(item))
+      return td
+    }
+  , compare: function(a, b) {
+      var va = options.value(a) || 0
+      var vb = options.value(b) || 0
+      return va - vb
+    }
+  , filter: (function() {
+      return function(item, filter) {
+        return filterOps[filter.op || '='](
+          options.value(item)
+        , Number(filter.query)
+        )
+      }
+    })()
+  })
+}
+
+function dateCell(options) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'desc'
+  , build: function() {
+      var td = document.createElement('td')
+      td.appendChild(document.createTextNode(''))
+      return td
+    }
+  , update: function(td, item) {
+      var t = td.firstChild
+      var date = options.value(item)
+      if (date) {
+        t.nodeValue = date.getFullYear() +
+          '-' +
+          zeroPadTwoDigit(date.getMonth() + 1) +
+          '-' +
+          zeroPadTwoDigit(date.getDate())
+      }
+      else {
+        t.nodeValue = ''
+      }
+      return td
+    }
+  , compare: function(a, b) {
+      var va = options.value(a) || 0
+      var vb = options.value(b) || 0
+      return va - vb
+    }
+  , filter: (function() {
+      function dateNumber(d) {
+        return d ?
+          d.getFullYear() * 10000 + d.getMonth() * 100 + d.getDate() :
+          0
+      }
+      return function(item, filter) {
+        var filterDate = new Date(filter.query)
+        var va = dateNumber(options.value(item))
+        var vb = dateNumber(filterDate)
+        return filterOps[filter.op || '='](va, vb)
+      }
+    })()
+  })
+}
+
+function linkCell(options) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      var a = document.createElement('a')
+      a.appendChild(document.createTextNode(''))
+      td.appendChild(a)
+      return td
+    }
+  , update: function(td, item) {
+      var a = td.firstChild
+      var t = a.firstChild
+      var href = options.link(item)
+      if (href) {
+        a.setAttribute('href', href)
+      }
+      else {
+        a.removeAttribute('href')
+      }
+      a.target = options.target || ''
+      t.nodeValue = options.value(item)
+      return td
+    }
+  , compare: function(a, b) {
+      return compareIgnoreCase(options.value(a), options.value(b))
+    }
+  , filter: function(item, filter) {
+      return filterIgnoreCase(options.value(item), filter.query)
+    }
+  })
+}
+
+function deviceBrowserCell(options) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      var span = document.createElement('span')
+      span.className = 'device-browser-list'
+      td.appendChild(span)
+      return td
+    }
+  , update: function(td, device) {
+      var span = td.firstChild
+      var browser = options.value(device)
+      var apps = browser.apps.slice().sort(function(appA, appB) {
+            return compareIgnoreCase(appA.name, appB.name)
+          })
+
+      for (var i = 0, l = apps.length; i < l; ++i) {
+        var app = apps[i]
+        var img = span.childNodes[i] || span.appendChild(document.createElement('img'))
+        var src = '/static/app/browsers/icon/36x36/' + (app.type || '_default') + '.png'
+
+        // Only change if necessary so that we don't trigger a download
+        if (img.getAttribute('src') !== src) {
+          img.setAttribute('src', src)
+        }
+
+        img.title = app.name + ' (' + app.developer + ')'
+      }
+
+      while (span.childNodes.length > browser.apps.length) {
+        span.removeChild(span.lastChild)
+      }
+
+      return td
+    }
+  , compare: function(a, b) {
+      return options.value(a).apps.length - options.value(b).apps.length
+    }
+  , filter: function(device, filter) {
+      return options.value(device).apps.some(function(app) {
+        return filterIgnoreCase(app.type, filter.query)
+      })
+    }
+  })
+}
+
+function deviceModelCell(options) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      var span = document.createElement('span')
+      var image = document.createElement('img')
+      span.className = 'device-small-image'
+      image.className = 'device-small-image-img pointer'
+      span.appendChild(image)
+      td.appendChild(span)
+      td.appendChild(document.createTextNode(''))
+      return td
+    }
+  , update: function(td, device) {
+      var span = td.firstChild
+      var image = span.firstChild
+      var t = span.nextSibling
+      var src = '/static/app/devices/icon/x24/' +
+            (device.image || '_default.jpg')
+
+      // Only change if necessary so that we don't trigger a download
+      if (image.getAttribute('src') !== src) {
+        image.setAttribute('src', src)
+      }
+
+      t.nodeValue = options.value(device)
+
+      return td
+    }
+  , compare: function(a, b) {
+      return compareRespectCase(options.value(a), options.value(b))
+    }
+  , filter: function(device, filter) {
+      return filterIgnoreCase(options.value(device), filter.query)
+    }
+  })
+}
+
+function deviceNameCell(options, ownerEmail) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      var a = document.createElement('a')
+      a.appendChild(document.createTextNode(''))
+      td.appendChild(a)
+      return td
+    }
+  , update: function(td, device) {
+      var a = td.firstChild
+      var t = a.firstChild
+
+      if (device.using && device.owner.email === ownerEmail) {
+        a.className = 'device-product-name-using'
+        a.href = '#!/control/' + device.serial
+      }
+      else if (device.usable && !device.using) {
+        a.className = 'device-product-name-usable'
+        a.href = '#!/control/' + device.serial
+      }
+      else {
+        a.className = 'device-product-name-unusable'
+        a.removeAttribute('href')
+      }
+
+      t.nodeValue = options.value(device)
+
+      return td
+    }
+  , compare: function(a, b) {
+      return compareIgnoreCase(options.value(a), options.value(b))
+    }
+  , filter: function(device, filter) {
+      return filterIgnoreCase(options.value(device), filter.query)
+    }
+  })
+}
+
+function deviceStatusCell(options) {
+  var stateClasses = {
+    using: 'state-using btn-primary'
+  , busy: 'state-busy btn-warning'
+  , available: 'state-available btn-primary-outline'
+  , ready: 'state-ready btn-primary-outline'
+  , present: 'state-present btn-primary-outline'
+  , preparing: 'state-preparing btn-primary-outline btn-success-outline'
+  , unauthorized: 'state-unauthorized btn-danger-outline'
+  , offline: 'state-offline btn-warning-outline'
+  , automation: 'state-automation btn-info'
+  }
+
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      var a = document.createElement('a')
+      a.appendChild(document.createTextNode(''))
+      td.appendChild(a)
+      return td
+    }
+  , update: function(td, device) {
+      var a = td.firstChild
+      var t = a.firstChild
+
+      a.className = 'btn btn-xs device-status ' +
+        (stateClasses[device.state] || 'btn-default-outline')
+
+      if (device.usable && !device.using) {
+        a.href = '#!/control/' + device.serial
+      }
+      else {
+        a.removeAttribute('href')
+      }
+
+      t.nodeValue = options.value(device)
+
+      return td
+    }
+  , compare: (function() {
+      var order = {
+        using: 10
+      , automation: 15
+      , available: 20
+      , busy: 30
+      , ready: 40
+      , preparing: 50
+      , unauthorized: 60
+      , offline: 70
+      , present: 80
+      , absent: 90
+      }
+      return function(deviceA, deviceB) {
+        return order[deviceA.state] - order[deviceB.state]
+      }
+    })()
+  , filter: function(device, filter) {
+      return device.state === filter.query
+    }
+  })
+}
+
+function deviceNoteCell(options) {
+  return _.defaults(options, {
+    title: options.title
+  , defaultOrder: 'asc'
+  , build: function() {
+      var td = document.createElement('td')
+      var span = document.createElement('span')
+      var i = document.createElement('i')
+
+      td.className = 'device-note'
+      span.className = 'xeditable-wrapper'
+      span.appendChild(document.createTextNode(''))
+
+      i.className = 'device-note-edit fa fa-pencil pointer'
+
+      td.appendChild(span)
+      td.appendChild(i)
+
+      return td
+    }
+  , update: function(td, item) {
+      var span = td.firstChild
+      var t = span.firstChild
+
+      t.nodeValue = options.value(item)
+      return td
+    }
+  , compare: function(a, b) {
+      return compareIgnoreCase(options.value(a), options.value(b))
+    }
+  , filter: function(item, filter) {
+      return filterIgnoreCase(options.value(item), filter.query)
+    }
+  })
+}
+
 module.exports = function DeviceColumnService($filter, gettext, SettingsService, AppState) {
   // Definitions for all possible values.
   return {
-    state: DeviceStatusCell({
+    state: deviceStatusCell({
       title: gettext('Status')
     , value: function(device) {
         return $filter('translate')(device.enhancedStateAction)
       }
     })
-  , group: TextCell({
+  , group: textCell({
       title: gettext('Group Name')
     , value: function(device) {
         return $filter('translate')(device.group.name)
       }
     })
-  , groupSchedule: TextCell({
+  , groupSchedule: textCell({
       title: gettext('Group Class')
     , value: function(device) {
         return $filter('translate')(device.group.class)
       }
     })
-  , groupOwner: LinkCell({
+  , groupOwner: linkCell({
       title: gettext('Group Owner')
     , target: '_blank'
     , value: function(device) {
@@ -53,55 +451,55 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
         return device.enhancedGroupOwnerProfileUrl
       }
     })
-  , groupEndTime: TextCell({
+  , groupEndTime: textCell({
       title: gettext('Group Expiration Date')
     , value: function(device) {
         return $filter('date')(device.group.lifeTime.stop, SettingsService.get('dateFormat'))
       }
     })
-  , groupStartTime: TextCell({
+  , groupStartTime: textCell({
       title: gettext('Group Starting Date')
     , value: function(device) {
         return $filter('date')(device.group.lifeTime.start, SettingsService.get('dateFormat'))
       }
     })
-  , groupRepetitions: TextCell({
+  , groupRepetitions: textCell({
       title: gettext('Group Repetitions')
     , value: function(device) {
         return device.group.repetitions
       }
     })
-  , groupOrigin: TextCell({
+  , groupOrigin: textCell({
       title: gettext('Group Origin')
     , value: function(device) {
         return $filter('translate')(device.group.originName)
       }
     })
-  , model: DeviceModelCell({
+  , model: deviceModelCell({
       title: gettext('Model')
     , value: function(device) {
         return device.model || device.serial
       }
     })
-  , name: DeviceNameCell({
+  , name: deviceNameCell({
       title: gettext('Product')
     , value: function(device) {
         return device.name || device.model || device.serial
       }
     }, AppState.user.email)
-  , operator: TextCell({
+  , operator: textCell({
       title: gettext('Carrier')
     , value: function(device) {
         return device.operator || ''
       }
     })
-  , releasedAt: DateCell({
+  , releasedAt: dateCell({
       title: gettext('Released')
     , value: function(device) {
         return device.releasedAt ? new Date(device.releasedAt) : null
       }
     })
-  , version: TextCell({
+  , version: textCell({
       title: gettext('OS')
     , value: function(device) {
         return device.version || ''
@@ -175,7 +573,7 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
         return true
       }
     })
-  , network: TextCell({
+  , network: textCell({
       title: gettext('Network')
     , value: function(device) {
         if (!device.network) {
@@ -193,7 +591,7 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
         return (device.network.type || '').toUpperCase()
       }
     })
-  , display: TextCell({
+  , display: textCell({
       title: gettext('Screen')
     , defaultOrder: 'desc'
     , value: function(device) {
@@ -211,31 +609,31 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
         return va - vb
       }
     })
-  , browser: DeviceBrowserCell({
+  , browser: deviceBrowserCell({
       title: gettext('Browser')
     , value: function(device) {
         return device.browser || {apps: []}
       }
     })
-  , serial: TextCell({
+  , serial: textCell({
       title: gettext('Serial')
     , value: function(device) {
         return device.serial || ''
       }
     })
-  , manufacturer: TextCell({
+  , manufacturer: textCell({
       title: gettext('Manufacturer')
     , value: function(device) {
         return device.manufacturer || ''
       }
     })
-  , marketName: TextCell({
+  , marketName: textCell({
     title: gettext('Market name')
     , value: function(device) {
       return device.marketName || ''
     }
   })
-  , sdk: NumberCell({
+  , sdk: numberCell({
       title: gettext('SDK')
     , defaultOrder: 'desc'
     , value: function(device) {
@@ -245,49 +643,49 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
         return value || ''
       }
     })
-  , abi: TextCell({
+  , abi: textCell({
       title: gettext('ABI')
     , value: function(device) {
         return device.abi || ''
       }
     })
-  , cpuPlatform: TextCell({
+  , cpuPlatform: textCell({
       title: gettext('CPU Platform')
     , value: function(device) {
         return device.cpuPlatform || ''
       }
     })
-  , openGLESVersion: TextCell({
+  , openGLESVersion: textCell({
       title: gettext('OpenGL ES version')
     , value: function(device) {
         return device.openGLESVersion || ''
       }
     })
-  , phone: TextCell({
+  , phone: textCell({
       title: gettext('Phone')
     , value: function(device) {
         return device.phone ? device.phone.phoneNumber : ''
       }
     })
-  , imei: TextCell({
+  , imei: textCell({
       title: gettext('Phone IMEI')
     , value: function(device) {
         return device.phone ? device.phone.imei : ''
       }
     })
-  , imsi: TextCell({
+  , imsi: textCell({
       title: gettext('Phone IMSI')
     , value: function(device) {
         return device.phone ? device.phone.imsi : ''
       }
     })
-  , iccid: TextCell({
+  , iccid: textCell({
       title: gettext('Phone ICCID')
     , value: function(device) {
         return device.phone ? device.phone.iccid : ''
       }
     })
-  , batteryHealth: TextCell({
+  , batteryHealth: textCell({
       title: gettext('Battery Health')
     , value: function(device) {
         return device.battery ?
@@ -295,7 +693,7 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
           ''
       }
     })
-  , batterySource: TextCell({
+  , batterySource: textCell({
       title: gettext('Battery Source')
     , value: function(device) {
         return device.battery ?
@@ -303,7 +701,7 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
           ''
       }
     })
-  , batteryStatus: TextCell({
+  , batteryStatus: textCell({
       title: gettext('Battery Status')
     , value: function(device) {
         return device.battery ?
@@ -311,7 +709,7 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
           ''
       }
     })
-  , batteryLevel: NumberCell({
+  , batteryLevel: numberCell({
       title: gettext('Battery Level')
     , value: function(device) {
         return device.battery ?
@@ -322,7 +720,7 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
         return value === null ? '' : value + '%'
       }
     })
-  , batteryTemp: NumberCell({
+  , batteryTemp: numberCell({
       title: gettext('Battery Temp')
     , value: function(device) {
         return device.battery ? device.battery.temp : null
@@ -331,19 +729,19 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
         return value === null ? '' : value + '°C'
       }
     })
-  , provider: TextCell({
+  , provider: textCell({
       title: gettext('Location')
     , value: function(device) {
         return device.provider ? device.provider.name : ''
       }
     })
-  , notes: DeviceNoteCell({
+  , notes: deviceNoteCell({
       title: gettext('Notes')
     , value: function(device) {
         return device.notes || ''
       }
     })
-  , owner: LinkCell({
+  , owner: linkCell({
       title: gettext('User')
     , target: '_blank'
     , value: function(device) {
@@ -354,400 +752,4 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
       }
     })
   }
-}
-
-function zeroPadTwoDigit(digit) {
-  return digit < 10 ? '0' + digit : '' + digit
-}
-
-function compareIgnoreCase(a, b) {
-/* **** fix bug: cast to String for Safari compatibility **** */
-  var la = (String(a) || '').toLowerCase()
-  var lb = (String(b) || '').toLowerCase()
-/***********************************************************/
-  if (la === lb) {
-    return 0
-  }
-  else {
-    return la < lb ? -1 : 1
-  }
-}
-
-function filterIgnoreCase(a, filterValue) {
-/* **** fix bug: cast to String for Safari compatibility **** */
-  var va = (String(a) || '').toLowerCase()
-  var vb = String(filterValue).toLowerCase()
-/***********************************************************/
-  return va.indexOf(vb) !== -1
-}
-
-function compareRespectCase(a, b) {
-  if (a === b) {
-    return 0
-  }
-  else {
-    return a < b ? -1 : 1
-  }
-}
-
-
-function TextCell(options) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      td.appendChild(document.createTextNode(''))
-      return td
-    }
-  , update: function(td, item) {
-      var t = td.firstChild
-      t.nodeValue = options.value(item)
-      return td
-    }
-  , compare: function(a, b) {
-      return compareIgnoreCase(options.value(a), options.value(b))
-    }
-  , filter: function(item, filter) {
-      return filterIgnoreCase(options.value(item), filter.query)
-    }
-  })
-}
-
-function NumberCell(options) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      td.appendChild(document.createTextNode(''))
-      return td
-    }
-  , update: function(td, item) {
-      var t = td.firstChild
-      t.nodeValue = options.format(options.value(item))
-      return td
-    }
-  , compare: function(a, b) {
-      var va = options.value(a) || 0
-      var vb = options.value(b) || 0
-      return va - vb
-    }
-  , filter: (function() {
-      return function(item, filter) {
-        return filterOps[filter.op || '='](
-          options.value(item)
-        , Number(filter.query)
-        )
-      }
-    })()
-  })
-}
-
-function DateCell(options) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'desc'
-  , build: function() {
-      var td = document.createElement('td')
-      td.appendChild(document.createTextNode(''))
-      return td
-    }
-  , update: function(td, item) {
-      var t = td.firstChild
-      var date = options.value(item)
-      if (date) {
-        t.nodeValue = date.getFullYear() +
-          '-' +
-          zeroPadTwoDigit(date.getMonth() + 1) +
-          '-' +
-          zeroPadTwoDigit(date.getDate())
-      }
-      else {
-        t.nodeValue = ''
-      }
-      return td
-    }
-  , compare: function(a, b) {
-      var va = options.value(a) || 0
-      var vb = options.value(b) || 0
-      return va - vb
-    }
-  , filter: (function() {
-      function dateNumber(d) {
-        return d ?
-          d.getFullYear() * 10000 + d.getMonth() * 100 + d.getDate() :
-          0
-      }
-      return function(item, filter) {
-        var filterDate = new Date(filter.query)
-        var va = dateNumber(options.value(item))
-        var vb = dateNumber(filterDate)
-        return filterOps[filter.op || '='](va, vb)
-      }
-    })()
-  })
-}
-
-function LinkCell(options) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      var a = document.createElement('a')
-      a.appendChild(document.createTextNode(''))
-      td.appendChild(a)
-      return td
-    }
-  , update: function(td, item) {
-      var a = td.firstChild
-      var t = a.firstChild
-      var href = options.link(item)
-      if (href) {
-        a.setAttribute('href', href)
-      }
-      else {
-        a.removeAttribute('href')
-      }
-      a.target = options.target || ''
-      t.nodeValue = options.value(item)
-      return td
-    }
-  , compare: function(a, b) {
-      return compareIgnoreCase(options.value(a), options.value(b))
-    }
-  , filter: function(item, filter) {
-      return filterIgnoreCase(options.value(item), filter.query)
-    }
-  })
-}
-
-function DeviceBrowserCell(options) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      var span = document.createElement('span')
-      span.className = 'device-browser-list'
-      td.appendChild(span)
-      return td
-    }
-  , update: function(td, device) {
-      var span = td.firstChild
-      var browser = options.value(device)
-      var apps = browser.apps.slice().sort(function(appA, appB) {
-            return compareIgnoreCase(appA.name, appB.name)
-          })
-
-      for (var i = 0, l = apps.length; i < l; ++i) {
-        var app = apps[i]
-        var img = span.childNodes[i] || span.appendChild(document.createElement('img'))
-        var src = '/static/app/browsers/icon/36x36/' + (app.type || '_default') + '.png'
-
-        // Only change if necessary so that we don't trigger a download
-        if (img.getAttribute('src') !== src) {
-          img.setAttribute('src', src)
-        }
-
-        img.title = app.name + ' (' + app.developer + ')'
-      }
-
-      while (span.childNodes.length > browser.apps.length) {
-        span.removeChild(span.lastChild)
-      }
-
-      return td
-    }
-  , compare: function(a, b) {
-      return options.value(a).apps.length - options.value(b).apps.length
-    }
-  , filter: function(device, filter) {
-      return options.value(device).apps.some(function(app) {
-        return filterIgnoreCase(app.type, filter.query)
-      })
-    }
-  })
-}
-
-function DeviceModelCell(options) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      var span = document.createElement('span')
-      var image = document.createElement('img')
-      span.className = 'device-small-image'
-      image.className = 'device-small-image-img pointer'
-      span.appendChild(image)
-      td.appendChild(span)
-      td.appendChild(document.createTextNode(''))
-      return td
-    }
-  , update: function(td, device) {
-      var span = td.firstChild
-      var image = span.firstChild
-      var t = span.nextSibling
-      var src = '/static/app/devices/icon/x24/' +
-            (device.image || '_default.jpg')
-
-      // Only change if necessary so that we don't trigger a download
-      if (image.getAttribute('src') !== src) {
-        image.setAttribute('src', src)
-      }
-
-      t.nodeValue = options.value(device)
-
-      return td
-    }
-  , compare: function(a, b) {
-      return compareRespectCase(options.value(a), options.value(b))
-    }
-  , filter: function(device, filter) {
-      return filterIgnoreCase(options.value(device), filter.query)
-    }
-  })
-}
-
-function DeviceNameCell(options, ownerEmail) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      var a = document.createElement('a')
-      a.appendChild(document.createTextNode(''))
-      td.appendChild(a)
-      return td
-    }
-  , update: function(td, device) {
-      var a = td.firstChild
-      var t = a.firstChild
-
-      if (device.using && device.owner.email === ownerEmail) {
-        a.className = 'device-product-name-using'
-        a.href = '#!/control/' + device.serial
-      }
-      else if (device.usable && !device.using) {
-        a.className = 'device-product-name-usable'
-        a.href = '#!/control/' + device.serial
-      }
-      else {
-        a.className = 'device-product-name-unusable'
-        a.removeAttribute('href')
-      }
-
-      t.nodeValue = options.value(device)
-
-      return td
-    }
-  , compare: function(a, b) {
-      return compareIgnoreCase(options.value(a), options.value(b))
-    }
-  , filter: function(device, filter) {
-      return filterIgnoreCase(options.value(device), filter.query)
-    }
-  })
-}
-
-function DeviceStatusCell(options) {
-  var stateClasses = {
-    using: 'state-using btn-primary'
-  , busy: 'state-busy btn-warning'
-  , available: 'state-available btn-primary-outline'
-  , ready: 'state-ready btn-primary-outline'
-  , present: 'state-present btn-primary-outline'
-  , preparing: 'state-preparing btn-primary-outline btn-success-outline'
-  , unauthorized: 'state-unauthorized btn-danger-outline'
-  , offline: 'state-offline btn-warning-outline'
-  , automation: 'state-automation btn-info'
-  }
-
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      var a = document.createElement('a')
-      a.appendChild(document.createTextNode(''))
-      td.appendChild(a)
-      return td
-    }
-  , update: function(td, device) {
-      var a = td.firstChild
-      var t = a.firstChild
-
-      a.className = 'btn btn-xs device-status ' +
-        (stateClasses[device.state] || 'btn-default-outline')
-
-      if (device.usable && !device.using) {
-        a.href = '#!/control/' + device.serial
-      }
-      else {
-        a.removeAttribute('href')
-      }
-
-      t.nodeValue = options.value(device)
-
-      return td
-    }
-  , compare: (function() {
-      var order = {
-        using: 10
-      , automation: 15
-      , available: 20
-      , busy: 30
-      , ready: 40
-      , preparing: 50
-      , unauthorized: 60
-      , offline: 70
-      , present: 80
-      , absent: 90
-      }
-      return function(deviceA, deviceB) {
-        return order[deviceA.state] - order[deviceB.state]
-      }
-    })()
-  , filter: function(device, filter) {
-      return device.state === filter.query
-    }
-  })
-}
-
-function DeviceNoteCell(options) {
-  return _.defaults(options, {
-    title: options.title
-  , defaultOrder: 'asc'
-  , build: function() {
-      var td = document.createElement('td')
-      var span = document.createElement('span')
-      var i = document.createElement('i')
-
-      td.className = 'device-note'
-      span.className = 'xeditable-wrapper'
-      span.appendChild(document.createTextNode(''))
-
-      i.className = 'device-note-edit fa fa-pencil pointer'
-
-      td.appendChild(span)
-      td.appendChild(i)
-
-      return td
-    }
-  , update: function(td, item) {
-      var span = td.firstChild
-      var t = span.firstChild
-
-      t.nodeValue = options.value(item)
-      return td
-    }
-  , compare: function(a, b) {
-      return compareIgnoreCase(options.value(a), options.value(b))
-    }
-  , filter: function(item, filter) {
-      return filterIgnoreCase(options.value(item), filter.query)
-    }
-  })
 }

--- a/res/app/device-list/details/device-list-details-directive.js
+++ b/res/app/device-list/details/device-list-details-directive.js
@@ -202,39 +202,35 @@ module.exports = function DeviceListDetailsDirective(
         }
       }
 
-      // Watch for sorting changes
-      scope.$watch(
-        function() {
-          return scope.sort
-        }
-      , function(newValue) {
-          activeSorting = newValue.fixed.concat(newValue.user)
-          scope.sortedColumns = Object.create(null)
-          activeSorting.forEach(function(sort) {
-            scope.sortedColumns[sort.name] = sort
-          })
-          sortAll()
-        }
-      , true
-      )
-
-      // Watch for column updates
-      scope.$watch(
-        function() {
-          return scope.columns()
-        }
-      , function(newValue) {
-          updateColumns(newValue)
-        }
-      , true
-      )
-
-      // Update now so that we don't have to wait for the scope watcher to
-      // trigger.
-      updateColumns(scope.columns())
-
       // Updates visible columns. This method doesn't necessarily have to be
       // the fastest because it shouldn't get called all the time.
+      function patchRow(tr, device, patch) {
+        for (var i = 0, l = patch.length; i < l; ++i) {
+          var op = patch[i]
+          switch (op[0]) {
+          case 'insert':
+            var col = scope.columnDefinitions[op[2]]
+            tr.insertBefore(col.update(col.build(), device), tr.cells[op[1]])
+            break
+          case 'remove':
+            tr.deleteCell(op[1])
+            break
+          case 'swap':
+            tr.insertBefore(tr.cells[op[1]], tr.cells[op[2]])
+            tr.insertBefore(tr.cells[op[2]], tr.cells[op[1]])
+            break
+          }
+        }
+
+        return tr
+      }
+
+      function patchAll(patch) {
+        for (var i = 0, l = rows.length; i < l; ++i) {
+          patchRow(rows[i], mapping[rows[i].id], patch)
+        }
+      }
+
       function updateColumns(columnSettings) {
         var newActiveColumns = []
 
@@ -255,29 +251,6 @@ module.exports = function DeviceListDetailsDirective(
       }
 
       // Updates filters on visible items.
-      function updateFilters(filters) {
-        activeFilters = filters
-        return filterAll()
-      }
-
-      // Applies filterRow() to all rows.
-      function filterAll() {
-        for (var i = 0, l = rows.length; i < l; ++i) {
-          filterRow(rows[i], mapping[rows[i].id])
-        }
-      }
-
-      // Filters a row, perhaps removing it from view.
-      function filterRow(row, device) {
-        if (match(device)) {
-          row.classList.remove('filter-out')
-        }
-        else {
-          row.classList.add('filter-out')
-        }
-      }
-
-      // Checks whether the device matches the currently active filters.
       function match(device) {
         for (var i = 0, l = activeFilters.length; i < l; ++i) {
           var filter = activeFilters[i]
@@ -304,6 +277,32 @@ module.exports = function DeviceListDetailsDirective(
         }
         return true
       }
+
+      function filterRow(row, device) {
+        if (match(device)) {
+          row.classList.remove('filter-out')
+        }
+        else {
+          row.classList.add('filter-out')
+        }
+      }
+
+      function filterAll() {
+        for (var i = 0, l = rows.length; i < l; ++i) {
+          filterRow(rows[i], mapping[rows[i].id])
+        }
+      }
+
+      function updateFilters(filters) {
+        activeFilters = filters
+        return filterAll()
+      }
+
+      // Applies filterRow() to all rows.
+
+      // Filters a row, perhaps removing it from view.
+
+      // Checks whether the device matches the currently active filters.
 
       // Update now so we're up to date.
       updateFilters(scope.filter())
@@ -374,35 +373,10 @@ module.exports = function DeviceListDetailsDirective(
       }
 
       // Patches all rows.
-      function patchAll(patch) {
-        for (var i = 0, l = rows.length; i < l; ++i) {
-          patchRow(rows[i], mapping[rows[i].id], patch)
-        }
-      }
 
       // Patches the given row by running the given patch operations in
       // order. The operations must take into account index changes caused
       // by previous operations.
-      function patchRow(tr, device, patch) {
-        for (var i = 0, l = patch.length; i < l; ++i) {
-          var op = patch[i]
-          switch (op[0]) {
-          case 'insert':
-            var col = scope.columnDefinitions[op[2]]
-            tr.insertBefore(col.update(col.build(), device), tr.cells[op[1]])
-            break
-          case 'remove':
-            tr.deleteCell(op[1])
-            break
-          case 'swap':
-            tr.insertBefore(tr.cells[op[1]], tr.cells[op[2]])
-            tr.insertBefore(tr.cells[op[2]], tr.cells[op[1]])
-            break
-          }
-        }
-
-        return tr
-      }
 
       // Updates all the columns in the row. Note that the row must be in
       // the right format already (built with createRow() and patched with
@@ -428,14 +402,6 @@ module.exports = function DeviceListDetailsDirective(
 
       // Inserts a row into the table into its correct position according to
       // current sorting.
-      function insertRow(tr, deviceA) {
-        return insertRowToSegment(tr, deviceA, 0, rows.length - 1)
-      }
-
-      // Inserts a row into a segment of the table into its correct position
-      // according to current sorting. The value of `hi` is the index
-      // of the last item in the segment, or -1 if none. The value of `lo`
-      // is the index of the first item in the segment, or 0 if none.
       function insertRowToSegment(tr, deviceA, low, high) {
         var total = rows.length
         var lo = low
@@ -481,6 +447,15 @@ module.exports = function DeviceListDetailsDirective(
           }
         }
       }
+
+      function insertRow(tr, deviceA) {
+        return insertRowToSegment(tr, deviceA, 0, rows.length - 1)
+      }
+
+      // Inserts a row into a segment of the table into its correct position
+      // according to current sorting. The value of `hi` is the index
+      // of the last item in the segment, or -1 if none. The value of `lo`
+      // is the index of the first item in the segment, or 0 if none.
 
       // Compares a row to its siblings to see if it's still in the correct
       // position. Returns <0 if the device should actually go somewhere
@@ -564,6 +539,37 @@ module.exports = function DeviceListDetailsDirective(
 
         delete mapping[id]
       }
+
+      // Watch for sorting changes
+      scope.$watch(
+        function() {
+          return scope.sort
+        }
+      , function(newValue) {
+          activeSorting = newValue.fixed.concat(newValue.user)
+          scope.sortedColumns = Object.create(null)
+          activeSorting.forEach(function(sort) {
+            scope.sortedColumns[sort.name] = sort
+          })
+          sortAll()
+        }
+      , true
+      )
+
+      // Watch for column updates
+      scope.$watch(
+        function() {
+          return scope.columns()
+        }
+      , function(newValue) {
+          updateColumns(newValue)
+        }
+      , true
+      )
+
+      // Update now so that we don't have to wait for the scope watcher to
+      // trigger.
+      updateColumns(scope.columns())
 
       tracker.on('add', addListener)
       tracker.on('change', changeListener)

--- a/res/app/device-list/device-list-controller.js
+++ b/res/app/device-list/device-list-controller.js
@@ -206,7 +206,7 @@ module.exports = function DeviceListCtrl(
     if (device.using) {
       $scope.kick(device)
     }
- else {
+    else {
       $location.path('/control/' + device.serial)
     }
   }

--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -9,7 +9,7 @@ module.exports = function DeviceListIconsDirective(
 , LogcatService
 , $rootScope
 ) {
-  function DeviceItem() {
+  function deviceItem() {
     return {
       build: function() {
         var li = document.createElement('li')
@@ -82,7 +82,7 @@ module.exports = function DeviceListIconsDirective(
         if (device.state === 'available') {
           name.classList.add('state-available')
         }
- else {
+        else {
           name.classList.remove('state-available')
         }
 
@@ -120,7 +120,7 @@ module.exports = function DeviceListIconsDirective(
       var items = list.childNodes
       var prefix = 'd' + Math.floor(Math.random() * 1000000) + '-'
       var mapping = Object.create(null)
-      var builder = DeviceItem()
+      var builder = deviceItem()
 
 
       function kickDevice(device, force) {
@@ -148,12 +148,12 @@ module.exports = function DeviceListIconsDirective(
         if (e.target.classList.contains('thumbnail')) {
           id = e.target.id
         }
- else if (e.target.classList.contains('device-status') ||
+        else if (e.target.classList.contains('device-status') ||
           e.target.classList.contains('device-photo-small') ||
           e.target.classList.contains('device-name')) {
           id = e.target.parentNode.parentNode.id
         }
- else if (e.target.parentNode.classList.contains('device-photo-small')) {
+        else if (e.target.parentNode.classList.contains('device-photo-small')) {
           id = e.target.parentNode.parentNode.parentNode.id
         }
 
@@ -222,39 +222,18 @@ module.exports = function DeviceListIconsDirective(
         }
       }
 
-      // Watch for sorting changes
-      scope.$watch(
-        function() {
-          return scope.sort
-        }
-      , function(newValue) {
-          activeSorting = newValue.fixed.concat(newValue.user)
-          scope.sortedColumns = Object.create(null)
-          activeSorting.forEach(function(sort) {
-            scope.sortedColumns[sort.name] = sort
-          })
-          sortAll()
-        }
-      , true
-      )
-
-      // Watch for column updates
-      scope.$watch(
-        function() {
-          return scope.columns()
-        }
-      , function(newValue) {
-          updateColumns(newValue)
-        }
-      , true
-      )
-
-      // Update now so that we don't have to wait for the scope watcher to
-      // trigger.
-      updateColumns(scope.columns())
-
       // Updates visible columns. This method doesn't necessarily have to be
       // the fastest because it shouldn't get called all the time.
+      function patchItem(/* item, device, patch*/) {
+        // Currently no-op
+      }
+
+      function patchAll(patch) {
+        for (var i = 0, l = items.length; i < l; ++i) {
+          patchItem(items[i], mapping[items[i].id], patch)
+        }
+      }
+
       function updateColumns(columnSettings) {
         var newActiveColumns = []
 
@@ -275,29 +254,6 @@ module.exports = function DeviceListIconsDirective(
       }
 
       // Updates filters on visible items.
-      function updateFilters(filters) {
-        activeFilters = filters
-        return filterAll()
-      }
-
-      // Applies filteItem() to all items.
-      function filterAll() {
-        for (var i = 0, l = items.length; i < l; ++i) {
-          filterItem(items[i], mapping[items[i].id])
-        }
-      }
-
-      // Filters an item, perhaps removing it from view.
-      function filterItem(item, device) {
-        if (match(device)) {
-          item.classList.remove('filter-out')
-        }
-        else {
-          item.classList.add('filter-out')
-        }
-      }
-
-      // Checks whether the device matches the currently active filters.
       function match(device) {
         for (var i = 0, l = activeFilters.length; i < l; ++i) {
           var filter = activeFilters[i]
@@ -324,6 +280,32 @@ module.exports = function DeviceListIconsDirective(
         }
         return true
       }
+
+      function filterItem(item, device) {
+        if (match(device)) {
+          item.classList.remove('filter-out')
+        }
+        else {
+          item.classList.add('filter-out')
+        }
+      }
+
+      function filterAll() {
+        for (var i = 0, l = items.length; i < l; ++i) {
+          filterItem(items[i], mapping[items[i].id])
+        }
+      }
+
+      function updateFilters(filters) {
+        activeFilters = filters
+        return filterAll()
+      }
+
+      // Applies filteItem() to all items.
+
+      // Filters an item, perhaps removing it from view.
+
+      // Checks whether the device matches the currently active filters.
 
       // Update now so we're up to date.
       updateFilters(scope.filter())
@@ -383,18 +365,10 @@ module.exports = function DeviceListIconsDirective(
       }
 
       // Patches all items.
-      function patchAll(patch) {
-        for (var i = 0, l = items.length; i < l; ++i) {
-          patchItem(items[i], mapping[items[i].id], patch)
-        }
-      }
 
       // Patches the given item by running the given patch operations in
       // order. The operations must take into account index changes caused
       // by previous operations.
-      function patchItem(/* item, device, patch*/) {
-        // Currently no-op
-      }
 
       // Updates all the columns in the item. Note that the item must be in
       // the right format already (built with createItem() and patched with
@@ -410,14 +384,6 @@ module.exports = function DeviceListIconsDirective(
 
       // Inserts an item into the table into its correct position according to
       // current sorting.
-      function insertItem(item, deviceA) {
-        return insertItemToSegment(item, deviceA, 0, items.length - 1)
-      }
-
-      // Inserts an item into a segment of the table into its correct position
-      // according to current sorting. The value of `hi` is the index
-      // of the last item in the segment, or -1 if none. The value of `lo`
-      // is the index of the first item in the segment, or 0 if none.
       function insertItemToSegment(item, deviceA, low, high) {
         var total = items.length
         var lo = low
@@ -463,6 +429,15 @@ module.exports = function DeviceListIconsDirective(
           }
         }
       }
+
+      function insertItem(item, deviceA) {
+        return insertItemToSegment(item, deviceA, 0, items.length - 1)
+      }
+
+      // Inserts an item into a segment of the table into its correct position
+      // according to current sorting. The value of `hi` is the index
+      // of the last item in the segment, or -1 if none. The value of `lo`
+      // is the index of the first item in the segment, or 0 if none.
 
       // Compares an item to its siblings to see if it's still in the correct
       // position. Returns <0 if the device should actually go somewhere
@@ -544,6 +519,37 @@ module.exports = function DeviceListIconsDirective(
 
         delete mapping[id]
       }
+
+      // Watch for sorting changes
+      scope.$watch(
+        function() {
+          return scope.sort
+        }
+      , function(newValue) {
+          activeSorting = newValue.fixed.concat(newValue.user)
+          scope.sortedColumns = Object.create(null)
+          activeSorting.forEach(function(sort) {
+            scope.sortedColumns[sort.name] = sort
+          })
+          sortAll()
+        }
+      , true
+      )
+
+      // Watch for column updates
+      scope.$watch(
+        function() {
+          return scope.columns()
+        }
+      , function(newValue) {
+          updateColumns(newValue)
+        }
+      , true
+      )
+
+      // Update now so that we don't have to wait for the scope watcher to
+      // trigger.
+      updateColumns(scope.columns())
 
       tracker.on('add', addListener)
       tracker.on('change', changeListener)

--- a/res/app/device-list/stats/device-list-stats-directive.js
+++ b/res/app/device-list/stats/device-list-stats-directive.js
@@ -73,15 +73,12 @@ module.exports = function DeviceListStatsDirective(
       }
 
       function removeListener(device) {
-        var oldStats = mapping[device.serial]
         var newStats = updateStats(device)
 
         scope.counter.total -= 1
         scope.counter.usable -= newStats.usable
         scope.counter.busy -= newStats.busy
         scope.counter.using -= newStats.using
-        // scope.counter.busy += newStats.busy - oldStats.busy
-        // scope.counter.using += newStats.using - oldStats.using
 
         delete mapping[device.serial]
 

--- a/res/app/device-list/util/query-parser/query-parser-test.js
+++ b/res/app/device-list/util/query-parser/query-parser-test.js
@@ -43,6 +43,7 @@ var tests = [
       }
     ])
   }
+
 /*
   This test is currently failing, but I'm not sure if I care enough about it.
   Commented out for now.

--- a/res/app/group-list/group-list-controller.js
+++ b/res/app/group-list/group-list-controller.js
@@ -149,6 +149,20 @@ module.exports = function GroupListCtrl(
     return group
   }
 
+  function addGroupUser(id, email, timeStamp) {
+    if (CommonService.isExisting(usersByEmail[email])) {
+      CommonService.add(
+        $scope.groupsEnv[id].users
+      , groupsEnv[id].usersByEmail
+      , users[usersByEmail[email].index]
+      , 'email'
+      , timeStamp)
+    }
+    else {
+      groupUserToAdd[email] = {id: id, timeStamp: timeStamp}
+    }
+  }
+
   function addUser(user, timeStamp) {
     if (CommonService.add(
           users
@@ -197,20 +211,6 @@ module.exports = function GroupListCtrl(
     , devicesBySerial
     , serial
     , timeStamp)
-  }
-
-  function addGroupUser(id, email, timeStamp) {
-    if (CommonService.isExisting(usersByEmail[email])) {
-      CommonService.add(
-        $scope.groupsEnv[id].users
-      , groupsEnv[id].usersByEmail
-      , users[usersByEmail[email].index]
-      , 'email'
-      , timeStamp)
-    }
-    else {
-      groupUserToAdd[email] = {id: id, timeStamp: timeStamp}
-    }
   }
 
   function deleteGroupUser(id, email, timeStamp) {

--- a/res/app/menu/menu-spec.js
+++ b/res/app/menu/menu-spec.js
@@ -1,11 +1,11 @@
 describe('MenuCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('MenuCtrl', {$scope: scope})
+    $controller('MenuCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/settings/devices/devices-spec.js
+++ b/res/app/settings/devices/devices-spec.js
@@ -5,11 +5,11 @@
 describe('DevicesCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('DevicesCtrl', {$scope: scope})
+    $controller('DevicesCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/settings/general/general-spec.js
+++ b/res/app/settings/general/general-spec.js
@@ -1,11 +1,11 @@
 describe('GeneralCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('GeneralCtrl', {$scope: scope})
+    $controller('GeneralCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/settings/groups/groups-controller.js
+++ b/res/app/settings/groups/groups-controller.js
@@ -48,7 +48,6 @@ module.exports = function GroupsCtrl(
     'groups.subscribed,' +
     'groups.quotas.allocated,' +
     'groups.quotas.consumed'
-  var rootGroupId
 
   function publishDevice(device) {
     if (!device.model) {
@@ -67,6 +66,22 @@ module.exports = function GroupsCtrl(
     $scope.groupsEnv[group.id].availableDevices.forEach(function(device) {
       publishDevice(device)
     })
+  }
+
+  function addStandardizableDevice(device, timeStamp) {
+    return CommonService.add(
+      standardizableDevices, standardizableDevicesBySerial, device, 'serial', timeStamp)
+  }
+
+  function updateStandardizableDevice(device, timeStamp) {
+    return CommonService.update(
+      standardizableDevices, standardizableDevicesBySerial, device, 'serial', timeStamp)
+  }
+
+  function addAvailableGroupDevice(id, device, timeStamp) {
+    return CommonService.add(
+      $scope.groupsEnv[id].availableDevices
+    , $scope.groupsEnv[id].availableDevicesBySerial, device, 'serial', timeStamp)
   }
 
   function getAvailableGroupDevices(group) {
@@ -146,9 +161,6 @@ module.exports = function GroupsCtrl(
     if (typeof $scope.groupsEnv[group.id] === 'undefined') {
       $scope.groupsEnv[group.id] = {}
       initAvailableGroupDevices(group, [], {})
-      if (group.privilege === 'root') {
-        rootGroupId = group.id
-      }
     }
     return group
   }
@@ -188,25 +200,9 @@ module.exports = function GroupsCtrl(
     return CommonService.delete(originDevices, originDevicesBySerial, serial, timeStamp)
   }
 
-  function addStandardizableDevice(device, timeStamp) {
-    return CommonService.add(
-      standardizableDevices, standardizableDevicesBySerial, device, 'serial', timeStamp)
-  }
-
-  function updateStandardizableDevice(device, timeStamp) {
-    return CommonService.update(
-      standardizableDevices, standardizableDevicesBySerial, device, 'serial', timeStamp)
-  }
-
   function deleteStandardizableDevice(serial, timeStamp) {
     return CommonService.delete(
       standardizableDevices, standardizableDevicesBySerial, serial, timeStamp)
-  }
-
-  function addAvailableGroupDevice(id, device, timeStamp) {
-    return CommonService.add(
-      $scope.groupsEnv[id].availableDevices
-    , $scope.groupsEnv[id].availableDevicesBySerial, device, 'serial', timeStamp)
   }
 
   function updateAvailableGroupDevice(id, device, timeStamp, noAdding) {
@@ -595,8 +591,8 @@ module.exports = function GroupsCtrl(
         GroupsService.addGroupDevices
     , deviceSearch ?
         [group.id, filteredDevices.map(function(device) {
- return device.serial
-}).join()] :
+          return device.serial
+        }).join()] :
         [group.id])
   }
 
@@ -615,8 +611,8 @@ module.exports = function GroupsCtrl(
         GroupsService.removeGroupDevices
     , deviceSearch ?
         [group.id, filteredDevices.map(function(device) {
- return device.serial
-}).join()] :
+          return device.serial
+        }).join()] :
         [group.id])
   }
 
@@ -631,8 +627,8 @@ module.exports = function GroupsCtrl(
       GroupsService.addGroupUsers
     , userSearch ?
         [group.id, filteredUsers.map(function(user) {
- return user.email
-}).join()] :
+          return user.email
+        }).join()] :
         [group.id])
   }
 
@@ -647,8 +643,8 @@ module.exports = function GroupsCtrl(
       GroupsService.removeGroupUsers
     , userSearch ?
         [group.id, filteredUsers.map(function(user) {
- return user.email
-}).join()] :
+          return user.email
+        }).join()] :
         [group.id])
   }
 
@@ -682,8 +678,8 @@ module.exports = function GroupsCtrl(
         CommonService.errorWrapper(
           GroupsService.removeGroups
         , [filteredGroups.map(function(group) {
- return group.id
-}).join()])
+          return group.id
+        }).join()])
       }
     }
 
@@ -833,7 +829,7 @@ module.exports = function GroupsCtrl(
           cachedGroupsClass[id] = response.data.group.class
           return cachedGroupsClass[id]
         })
-        .catch(function(error) {
+        .catch(function() {
           return false
         })
       }

--- a/res/app/settings/groups/groups-spec.js
+++ b/res/app/settings/groups/groups-spec.js
@@ -5,11 +5,11 @@
 describe('GroupsCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('GroupsCtrl', {$scope: scope})
+    $controller('GroupsCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/settings/keys/access-tokens/access-tokens-spec.js
+++ b/res/app/settings/keys/access-tokens/access-tokens-spec.js
@@ -1,11 +1,11 @@
 describe('AccessTokensCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('AccessTokensCtrl', {$scope: scope})
+    $controller('AccessTokensCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/settings/keys/adb-keys/adb-keys-spec.js
+++ b/res/app/settings/keys/adb-keys/adb-keys-spec.js
@@ -1,11 +1,11 @@
 describe('AdbKeysCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('AdbKeysCtrl', {$scope: scope})
+    $controller('AdbKeysCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/settings/keys/keys-spec.js
+++ b/res/app/settings/keys/keys-spec.js
@@ -1,11 +1,11 @@
 describe('KeysCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('KeysCtrl', {$scope: scope})
+    $controller('KeysCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/app/settings/users/users-controller.js
+++ b/res/app/settings/users/users-controller.js
@@ -116,8 +116,8 @@ module.exports = function UsersCtrl(
         UsersService.removeUsers
       , search ?
           [$scope.removingFilters, filteredUsers.map(function(user) {
- return user.email
-}).join()] :
+            return user.email
+          }).join()] :
           [$scope.removingFilters]
       )
     }

--- a/res/app/settings/users/users-spec.js
+++ b/res/app/settings/users/users-spec.js
@@ -5,11 +5,11 @@
 describe('UsersCtrl', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
-  var scope, ctrl
+  var scope
 
   beforeEach(inject(function($rootScope, $controller) {
     scope = $rootScope.$new()
-    ctrl = $controller('UsersCtrl', {$scope: scope})
+    $controller('UsersCtrl', {$scope: scope})
   }))
 
   it('should ...', inject(function() {

--- a/res/test/e2e/helpers/browser-logs.js
+++ b/res/test/e2e/helpers/browser-logs.js
@@ -28,7 +28,7 @@ module.exports = function BrowserLogs(opts) {
           if (log.level.value > 900) {
             console.error(browserStyled + chalk.white.bold(log.message))
           }
- else {
+          else {
             console.log(browserStyled + chalk.white.bold(log.message))
           }
         })

--- a/res/test/e2e/helpers/gulp-protractor-adv.js
+++ b/res/test/e2e/helpers/gulp-protractor-adv.js
@@ -129,7 +129,7 @@ var webdriverStandalone = function(opts, cb) {
     stdio: stdio
   })
     .once('close', callback)
-    .on('exit', function(code) {
+    .on('exit', function() {
       if (child) {
         child.kill()
       }
@@ -223,7 +223,7 @@ var protractorExplorer = function(opts, cb) {
       if (running) {
         runElementExplorer(callback)
       }
- else {
+      else {
         webdriverStandalone({stdio: ['pipe', 'pipe', process.stderr]},
           function() {
 

--- a/res/test/e2e/helpers/wait-url.js
+++ b/res/test/e2e/helpers/wait-url.js
@@ -6,17 +6,9 @@
  * @returns {!webdriver.promise.Promise} Promise
  */
 module.exports = function waitUrl(urlRegex) {
-  var currentUrl
-
-  return browser.getCurrentUrl().then(function storeCurrentUrl(url) {
-      currentUrl = url
-    }
-  ).then(function waitForUrlToChangeTo() {
-      return browser.wait(function waitForUrlToChangeTo() {
-        return browser.getCurrentUrl().then(function compareCurrentUrl(url) {
-          return urlRegex.test(url)
-        })
-      })
-    }
-  )
+  return browser.wait(function waitForUrlToChangeTo() {
+    return browser.getCurrentUrl().then(function compareCurrentUrl(url) {
+      return urlRegex.test(url)
+    })
+  })
 }

--- a/res/test/e2e/login/index.js
+++ b/res/test/e2e/login/index.js
@@ -10,7 +10,7 @@ module.exports = function LoginPage() {
   if (this.login.method === 'ldap') {
     this.password = element(by.model('password'))
   }
- else {
+  else {
     this.email = element(by.model('email'))
   }
 
@@ -48,7 +48,7 @@ module.exports = function LoginPage() {
     if (this.login.method === 'ldap') {
       this.setPassword(loginPassword)
     }
- else {
+    else {
       this.setEmail(loginEmail)
     }
 

--- a/res/test/karma.conf.js
+++ b/res/test/karma.conf.js
@@ -4,7 +4,6 @@
 
 var webpackConfig = require('./../../webpack.config')
 
-var webpack = require('webpack')
 
 module.exports = function(config) {
   config.set({

--- a/res/test/protractor.conf.js
+++ b/res/test/protractor.conf.js
@@ -1,6 +1,6 @@
 // Reference: https://github.com/angular/protractor/blob/master/referenceConf.js
 var LoginPage = require('./e2e/login')
-var BrowserLogs = require('./e2e/helpers/browser-logs')
+var browserLogs = require('./e2e/helpers/browser-logs')
 // var FailFast = require('./e2e/helpers/fail-fast')
 var jasmineReporters = require('jasmine-reporters')
 var WaitUrl = require('./e2e/helpers/wait-url')
@@ -80,7 +80,7 @@ module.exports.config = {
     })
 
     afterEach(function() {
-      BrowserLogs({expectNoLogs: true})
+      browserLogs({expectNoLogs: true})
       // FailFast()
     })
   }


### PR DESCRIPTION
Finishes #914. After this, `res/.eslintrc` has no `rules` block at all, so the browser tree is held to exactly the same config as `lib/`.

#914 left four rules muted under a note reading `// TODO: these four need code changes rather than a --fix pass`. This removes them. 272 problems (52 errors, 220 warnings) in 93 files:

| rule | n |
| --- | --- |
| `no-use-before-define` | 112 |
| `no-unused-vars` | 108 |
| `new-cap` | 41 |
| `lines-around-comment` | 11 |

None of it is autofixable, so unlike #914 every line here is hand written: functions hoisted above their first use, dead locals and two unused `require`s dropped, unused callback parameters trimmed off signatures.

## The part worth your attention

Two rules in the root `.eslintrc` are relaxed rather than obeyed. This is the only change outside `res/`:

```js
"lines-around-comment": [2, {"beforeBlockComment": true, "allowBlockStart": true}],
"new-cap": [2, {"capIsNewExceptionPattern": "Service$"}],
```

**`allowBlockStart`**, because the blank line the rule wants is at the top of a block, where `padded-blocks` forbids one. Both rules are on after #914 and neither can give way. All five sites look like `res/app/components/stf/screen/render/webgl-render.js:13`:

```js
var Renderer = function(gl) {
  /**
   * The GL context.
   */
```

**`capIsNewExceptionPattern`**, because angular injects services under their registered PascalCase name and they are then called as plain functions, which the rule reads as a missing `new`. Both sites are that:

```js
CompileCacheService(src, newScope, function(compiledElm) {   // include-cached-directive.js:11
ScopedHotkeysService($scope, [                               // control-panes-hotkeys-controller.js:90
```

Together those two account for **7 suppressions, all in `res/`**. I checked by reverting the root config on top of the code fixes: 5 `lines-around-comment`, 2 `new-cap`, zero in `lib/`. `lib/` is clean under either version, so nothing there loses coverage.

The other 39 `new-cap` reports were real and are fixed in code, not exempted.

## Three disable comments

Each carries a reason on the line above:

- `screen-directive.js:658` and `:845`, for genuinely mutual references. `stopMousing` and `stopTouching` unbind the very listeners that call them, so no ordering satisfies `no-use-before-define`.
- `device-service.js:138`, for a `fetch` function whose only call site is the commented-out block it is kept beside.

Happy to fold any of the three into a real fix if you would rather not carry them.

## Verification

0 errors, 0 warnings. Component tests 82/82.

`no-unused-vars` was the one with real regression risk, since dropping a variable can drop a side effect. The removals are limited to locals with no initializer call, two unused `require`s, and trailing parameters.
