### PR TITLE
Select on focus in textFocusSelect, and stop clobbering drag-selects

### DIFF
--- a/res/app/components/stf/common-ui/text-focus-select/text-focus-select-directive.js
+++ b/res/app/components/stf/common-ui/text-focus-select/text-focus-select-directive.js
@@ -2,9 +2,25 @@ module.exports = function textFocusSelectDirective() {
   return {
     restrict: 'AC'
     , link: function(scope, element) {
-      // TODO: try with focus event
-      element.bind('click', function() {
+      var selectOnMouseUp = false
+
+      element.bind('focus', function() {
+        selectOnMouseUp = true
         this.select()
+      })
+
+      // a focusing click collapses what focus just selected, so redo it, unless the user dragged out a range of their own
+      element.bind('mouseup', function() {
+        if (selectOnMouseUp) {
+          selectOnMouseUp = false
+          if (this.selectionStart === this.selectionEnd) {
+            this.select()
+          }
+        }
+      })
+
+      element.bind('blur', function() {
+        selectOnMouseUp = false
       })
     }
   }

--- a/res/app/components/stf/common-ui/text-focus-select/text-focus-select-spec.js
+++ b/res/app/components/stf/common-ui/text-focus-select/text-focus-select-spec.js
@@ -1,15 +1,98 @@
 describe('textFocusSelect', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  it('should ...', function() {
+  var scope, compile, element
 
-    /*
-     To test your directive, you need to create some html that would use your directive,
-     send that through compile() then compare the results.
+  beforeEach(inject(function($rootScope, $compile) {
+    scope = $rootScope.$new()
+    compile = $compile
+  }))
 
-     var element = compile('<div text-focus-select name="name">hi</div>')(scope);
-     expect(element.text()).toBe('hello, world');
-     */
+  afterEach(function() {
+    if (element) {
+      element.remove()
+      element = null
+    }
+  })
 
+  // focus and mouse events only behave like the browser once the node is in the document
+  function build(html) {
+    element = compile(html)(scope)
+    document.body.appendChild(element[0])
+    scope.$digest()
+    return element[0]
+  }
+
+  function input() {
+    return build('<input text-focus-select value="ssh-rsa AAAAB3">')
+  }
+
+  function fire(node, type) {
+    node.dispatchEvent(new MouseEvent(type, {bubbles: true, cancelable: true}))
+  }
+
+  // the tail of a real click, in the order the browser sends it
+  function releaseClick(node) {
+    fire(node, 'mouseup')
+    fire(node, 'click')
+  }
+
+  function selection(node) {
+    return [node.selectionStart, node.selectionEnd]
+  }
+
+  it('should put the selection back after a focusing click collapses it', function() {
+    var node = input()
+
+    node.focus()
+    node.setSelectionRange(3, 3)
+    releaseClick(node)
+
+    expect(selection(node)).toEqual([0, node.value.length])
+  })
+
+  it('should do the same for a readonly textarea', function() {
+    var tip = 'pbcopy &lt; ~/.android/adbkey.pub'
+    var node = build('<textarea text-focus-select readonly>' + tip + '</textarea>')
+
+    node.focus()
+    node.setSelectionRange(3, 3)
+    releaseClick(node)
+
+    expect(selection(node)).toEqual([0, node.value.length])
+  })
+
+  it('should leave a range the user dragged out alone', function() {
+    var node = input()
+
+    node.focus()
+    node.setSelectionRange(2, 5)
+    releaseClick(node)
+
+    expect(selection(node)).toEqual([2, 5])
+  })
+
+  it('should let a click on an already focused field place the caret', function() {
+    var node = input()
+
+    node.focus()
+    releaseClick(node)
+    node.setSelectionRange(4, 4)
+    releaseClick(node)
+
+    expect(selection(node)).toEqual([4, 4])
+  })
+
+  // a drag that starts elsewhere and is released over the field blurs it on
+  // mousedown, so the mouseup lands with no focus of its own to act on
+  it('should keep out of a field that lost focus before the mouse came up', function() {
+    var node = input()
+
+    node.focus()
+    node.blur()
+    node.setSelectionRange(3, 3)
+    fire(node, 'mouseup')
+
+    expect(selection(node)).toEqual([3, 3])
   })
 })


### PR DESCRIPTION
Closes the `// TODO: try with focus event` in `text-focus-select-directive.js`.

`text-focus-select` bound `select()` to `click`, so the text was only selected when you clicked the field. Tabbing in, or hitting the device search box's `accesskey='4'`, left it unselected.

Binding to `focus` on its own does not work either: in Chrome the order is mousedown, focus, mouseup, click, and that mouseup collapses what `focus` just selected. So `focus` selects, and the first mouseup after it puts the selection back, unless the user dragged out a range of their own.

```js
      var selectOnMouseUp = false

      element.bind('focus', function() {
        selectOnMouseUp = true
        this.select()
      })

      element.bind('mouseup', function() {
        if (selectOnMouseUp) {
          selectOnMouseUp = false
          if (this.selectionStart === this.selectionEnd) {
            this.select()
          }
        }
      })

      element.bind('blur', function() {
        selectOnMouseUp = false
      })
```

## It also fixes drag-select, which master breaks today

`click` fires at the end of a drag, and master's handler calls `select()` on it. So dragging out a substring in any `text-focus-select` field has never worked: the moment you release, the whole value gets selected instead.

## Measured in a running STF

`bin/stf local` on this branch and on master, driven through the Chrome DevTools Protocol with real mouse events on the device search box (`input.device-search`, 30 characters of text):

| Gesture | master | this branch |
| --- | --- | --- |
| Click into the unfocused box | selected | selected |
| Tab / accesskey focus | caret at 30, nothing selected | 0-30 selected |
| Drag into the box | 0-30, the drag is discarded | 0-19, the range actually dragged |
| Click again while focused | reselects everything | places the caret |

The tab-focus row is the TODO's actual complaint, and the drag row is the regression that comes with the old implementation.

## Tests

The empty stub spec is replaced with five component specs that compile the directive onto a real element attached to `document.body` and fire `mouseup` then `click` in the browser's order.

| Spec | Fails on master |
| --- | --- |
| leaves a range the user dragged out alone | yes |
| lets a click on an already focused field place the caret | yes |
| puts the selection back after a focusing click collapses it | no |
| does the same for a readonly textarea | no |
| keeps out of a field that lost focus before the mouse came up | no |

The bottom three cannot be made red in karma: headless Chrome selects the whole value on **any** programmatic `.focus()`, so a spec that focuses an element cannot tell this directive apart from no directive at all. That is why the tab-focus path is verified in a running STF above rather than here. The three still guard the mouseup path against future changes.

`npm run test:component` (karma + jasmine + headless Chrome, the same job CI runs): 2 failures against the old directive, 86/86 pass with the fix. `eslint` reports 0 errors and 0 warnings.

Protractor was not used: those specs need a live STF with real devices, so they cannot run in CI.

