### PR TITLE
Reset the ADB key form when the add panel closes

### DIFF
--- a/res/app/components/stf/keys/add-adb-key/add-adb-key-directive.js
+++ b/res/app/components/stf/keys/add-adb-key/add-adb-key-directive.js
@@ -33,8 +33,7 @@ module.exports = function addAdbKeyDirective(AdbKeysService) {
       $scope.closeAddKey = function() {
         $scope.addForm.title = ''
         $scope.addForm.key = ''
-        // TODO: cannot access to the form by name inside a directive?
-        // $scope.adbkeyform.$setPristine()
+        $scope.adbkeyform.$setPristine()
         $scope.showAdd = false
         $scope.error = ''
       }

--- a/res/app/components/stf/keys/add-adb-key/add-adb-key-spec.js
+++ b/res/app/components/stf/keys/add-adb-key/add-adb-key-spec.js
@@ -1,16 +1,77 @@
 describe('addAdbKey', function() {
   beforeEach(angular.mock.module(require('./index').name))
 
+  // the directive controller injects UserService, which lives in the app module
+  beforeEach(angular.mock.module(function($provide) {
+    $provide.value('UserService', {addAdbKey: jasmine.createSpy('addAdbKey')})
+  }))
 
-  it('should ...', function() {
+  var scope, compile, element
 
-    /*
-     To test your directive, you need to create some html that would use your directive,
-     send that through compile() then compare the results.
+  beforeEach(inject(function($rootScope, $compile) {
+    scope = $rootScope.$new()
+    scope.showAdd = true
+    scope.showClipboard = true
+    compile = $compile
+  }))
 
-     var element = compile('<div add-adb-key name="name">hi</div>')(scope)
-     expect(element.text()).toBe('hello, world')
-     */
+  afterEach(function() {
+    if (element) {
+      element.remove()
+      element = null
+    }
+  })
 
+  function build() {
+    element = compile('<add-adb-key show-add="showAdd" show-clipboard="showClipboard"/>')(scope)
+    scope.$digest()
+    return element.isolateScope()
+  }
+
+  it('should publish the form on the isolate scope once the template has linked', function() {
+    expect(build().adbkeyform).toBeDefined()
+  })
+
+  it('should make the form pristine again when the panel is closed', function() {
+    var isolate = build()
+    isolate.adbkeyform.$setDirty()
+
+    isolate.closeAddKey()
+
+    expect(isolate.adbkeyform.$pristine).toBe(true)
+    expect(isolate.adbkeyform.$dirty).toBe(false)
+  })
+
+  it('should clear the submitted flag when the panel closes', function() {
+    var isolate = build()
+    isolate.adbkeyform.$setSubmitted()
+
+    isolate.closeAddKey()
+
+    expect(isolate.adbkeyform.$submitted).toBe(false)
+  })
+
+  it('should reset the form when the key list reports an update', function() {
+    var isolate = build()
+    isolate.adbkeyform.$setDirty()
+
+    scope.$broadcast('user.keys.adb.updated')
+
+    expect(isolate.adbkeyform.$pristine).toBe(true)
+  })
+
+  it('should still clear the fields, hide the panel and drop the error', function() {
+    var isolate = build()
+    isolate.addForm.title = 'laptop'
+    isolate.addForm.key = 'ssh-rsa AAAAB3'
+    isolate.error = 'nope'
+
+    isolate.closeAddKey()
+    scope.$digest()
+
+    expect(isolate.addForm.title).toBe('')
+    expect(isolate.addForm.key).toBe('')
+    expect(isolate.error).toBe('')
+    expect(scope.showAdd).toBe(false)
   })
 })


### PR DESCRIPTION
Closes the `// TODO: cannot access to the form by name inside a directive?` in `add-adb-key-directive.js`.

`closeAddKey()` cleared `addForm.title` and `addForm.key` but left the form controller dirty, because the reset was commented out:

```js
       $scope.closeAddKey = function() {
         $scope.addForm.title = ''
         $scope.addForm.key = ''
-        // TODO: cannot access to the form by name inside a directive?
-        //$scope.adbkeyform.$setPristine()
+        $scope.adbkeyform.$setPristine()
         $scope.showAdd = false
         $scope.error = ''
       }
```

The TODO's premise is wrong. `form(name='adbkeyform')` publishes its `FormController` onto the scope the form is compiled against, and since the template lives inside this directive's isolate scope, that is `$scope`. What is true is that it is not there yet while the `controller` function is running, which is probably what the original author hit. `closeAddKey()` only ever runs later, from the `user.keys.adb.updated` handler, by which time the template has linked. The first spec below asserts exactly that.

## Measured in a running STF

`bin/stf local`, Settings → Keys: open the panel, type a key and a device name, submit, close, reopen.

| | master | this branch |
| --- | --- | --- |
| form classes | `ng-dirty ng-submitted ng-invalid ng-invalid-required` | `ng-pristine ng-invalid ng-invalid-required` |
| `$dirty` / `$submitted` | `true` / `true` | `false` / `false` |
| input border colour | `rgb(204, 204, 204)` | `rgb(204, 204, 204)` |

**So this is a state fix, not a visible one.** Nothing in `add-adb-key.pug` is gated on `$dirty` or `$submitted`, and STF only styles `.ng-invalid` under `.stf-groups` and `.stf-users`, so the reopened panel looks identical either way today.

It is still worth doing: the models are cleared, so the controller should agree. `store-account.pug` next door already gates its validation warnings on `$dirty` (`ng-show='storeLogin.username.$dirty && storeLogin.username.$invalid'`), and the same hint added to this form would fire on a freshly reopened, untouched panel.

## Tests

| Spec | Fails on master |
| --- | --- |
| publishes the form on the isolate scope once the template has linked | no (documents why the TODO was wrong) |
| makes the form pristine again when the panel is closed | yes |
| clears the submitted flag when the panel closes | yes |
| resets the form when the key list reports an update | yes |
| still clears the fields, hides the panel and drops the error | no (regression guard) |

The specs compile the real `add-adb-key.pug` template. `UserService` is stubbed with `$provide.value` since it is registered in the app module, not in `stf.add-adb-key`.

`npm run test:component` (karma + jasmine + headless Chrome, the same job CI runs): 3 failures against the old directive, 90/90 pass with the fix. `eslint` reports 0 errors and 0 warnings.

Protractor was not used: those specs need a live STF with real devices, so they cannot run in CI.

