### PR TITLE
Turn the store account sign in spinner back on

### DIFF
--- a/res/app/control-panes/automation/store-account/store-account-spec.js
+++ b/res/app/control-panes/automation/store-account/store-account-spec.js
@@ -1,14 +1,78 @@
 describe('StoreAccountCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
+  beforeEach(angular.mock.module(require('gettext').name))
 
-  var scope
+  var scope, compile, catalog, template, element, ctrlScope
 
-  beforeEach(inject(function($rootScope, $controller) {
+  beforeEach(inject(function($rootScope, $compile, $templateCache, gettextCatalog) {
     scope = $rootScope.$new()
-    $controller('StoreAccountCtrl', {$scope: scope})
+    compile = $compile
+    catalog = gettextCatalog
+    template = $templateCache.get(
+      'control-panes/automation/store-account/store-account.pug')
   }))
 
-  it('should ...', inject(function() {
-    expect(1).toEqual(1)
-  }))
+  afterEach(function() {
+    if (element) {
+      element.remove()
+      element = null
+    }
+  })
+
+  // the widget root carries ng-controller, so addingAccount lives on its child scope
+  function build() {
+    element = compile(template)(scope)
+    document.body.appendChild(element[0])
+    scope.$digest()
+    ctrlScope = element.scope()
+    return element[0].querySelector('button[ng-click="addAccount()"]')
+  }
+
+  function setAdding(value) {
+    ctrlScope.addingAccount = value
+    ctrlScope.$digest()
+  }
+
+  it('should turn the sign in button into a ladda button', function() {
+    expect(build().className).toMatch('ladda-button')
+  })
+
+  it('should keep the translated label inside the ladda wrapper', function() {
+    var label = build().querySelector('.ladda-label')
+
+    expect(label).not.toBeNull()
+    expect(label.textContent).toMatch('Sign In')
+  })
+
+  it('should spin while an account is being added', function() {
+    var button = build()
+
+    setAdding(true)
+
+    expect(button.getAttribute('data-loading')).not.toBeNull()
+    expect(button.querySelector('.ladda-spinner')).not.toBeNull()
+  })
+
+  it('should stop spinning and keep its label once the add settles', function() {
+    var button = build()
+
+    setAdding(true)
+    setAdding(false)
+
+    expect(button.getAttribute('data-loading')).toBeNull()
+    expect(button.querySelector('.ladda-label').textContent).toMatch('Sign In')
+  })
+
+  // the old comment blamed gettext for ladda being switched off
+  it('should retranslate the label without losing the ladda wrapper', function() {
+    var button = build()
+
+    catalog.setStrings('fr', {'Sign In': 'Se connecter'})
+    catalog.setCurrentLanguage('fr')
+    ctrlScope.$digest()
+
+    expect(button.className).toMatch('ladda-button')
+    expect(button.querySelector('.ladda-label').textContent).toMatch('Se connecter')
+    expect(button.querySelector('.ladda-spinner')).not.toBeNull()
+  })
 })

--- a/res/app/control-panes/automation/store-account/store-account.pug
+++ b/res/app/control-panes/automation/store-account/store-account.pug
@@ -31,10 +31,8 @@
             ng-model='currentAppStore', uib-btn-radio='currentAppStore', uib-tooltip='{{a.name}}')
             img(ng-src='/static/app/appstores/icon/24x24/{{a.type}}.png', ng-show='a.type').appstore-icon.pointer
 
-        // TODO: ladda disabled for now because of a gettext bug
         button.btn.btn-sm.btn-primary-outline(ng-click='addAccount()', ng-disabled='storeLogin.$invalid',
-        ladda-DISABLED='addingAccount', data-style='expand-left', data-spinner-color='#157afb').pull-right
-          i.fa.fa-spinner.fa-spin.fa-fw(ng-show='addingAccount')
+        ladda='addingAccount', data-style='expand-left', data-spinner-color='#157afb').pull-right
           i.fa.fa-sign-in.fa-fw
           span(translate) Sign In
 

--- a/res/web_modules/angular-ladda/index.js
+++ b/res/web_modules/angular-ladda/index.js
@@ -1,8 +1,6 @@
 
-// window.Ladda = require('ladda/js/ladda')
 require('angular-ladda/src/angular-ladda')
 
 module.exports = {
-  // Ladda: window.Ladda,
   name: 'angular-ladda'
 }

--- a/res/web_modules/ladda/index.js
+++ b/res/web_modules/ladda/index.js
@@ -1,3 +1,4 @@
 require('ladda/dist/ladda-themeless.min.css')
-require('ladda/dist/spin.min.js')
-require('ladda/dist/ladda.min.js')
+
+// ladda.min.js is UMD, so under webpack it exports rather than setting window.Ladda
+module.exports = require('ladda/dist/ladda.min.js')


### PR DESCRIPTION
Closes the `// TODO: ladda disabled for now because of a gettext bug` in `store-account.pug`.

**It was never a gettext bug.** `res/web_modules/ladda/index.js` required `ladda.min.js` but exported nothing:

```js
 require('ladda/dist/ladda-themeless.min.css')
-require('ladda/dist/spin.min.js')
-require('ladda/dist/ladda.min.js')
+
+module.exports = require('ladda/dist/ladda.min.js')
```

`ladda.min.js` is UMD (`"object"==typeof exports?module.exports=e(require("spin.js")):...`), so under webpack it takes the CommonJS branch and never assigns `window.Ladda`. `angular-ladda` does `require('ladda')`, got `{}` back, and `Ladda.create(element[0])` threw `TypeError: Ladda.create is not a function` the moment the attribute went live. Turning the attribute on without fixing the shim just moves the failure, which is spec run **Red B** below.

`res/web_modules/angular-ladda/index.js` also loses a commented out `window.Ladda = require('ladda/js/ladda')` and its matching commented out export. That was an earlier attempt at this same problem and it now contradicts the working explanation next door.

The `spin.min.js` require goes with it: `ladda.min.js` pulls `spin.js` itself, which resolves to the `res/bower_components/spin.js` bower package.

## Template

```
-        // TODO: ladda disabled for now because of a gettext bug
         button.btn.btn-sm.btn-primary-outline(ng-click='addAccount()', ng-disabled='storeLogin.$invalid',
-        ladda-DISABLED='addingAccount', data-style='expand-left', data-spinner-color='#157afb').pull-right
-          i.fa.fa-spinner.fa-spin.fa-fw(ng-show='addingAccount')
+        ladda='addingAccount', data-style='expand-left', data-spinner-color='#157afb').pull-right
           i.fa.fa-sign-in.fa-fw
           span(translate) Sign In
```

The hand rolled `fa-spinner` was the stand-in added when ladda was switched off. Ladda draws its own spinner into `.ladda-spinner`, so keeping both would show two at once.

## Tests

The placeholder spec is replaced with five component specs that compile the real `store-account.pug` out of `$templateCache`. `addingAccount` is set on the `ng-controller` child scope, not the parent, or `StoreAccountCtrl`'s own `addingAccount = false` shadows it.

| Spec |
| --- |
| turns the sign in button into a ladda button |
| keeps the translated label inside the ladda wrapper |
| spins while an account is being added (`data-loading` + `.ladda-spinner`) |
| stops spinning and keeps its label once the add settles |
| retranslates the label without losing the ladda wrapper |

The last one is the direct test of the TODO's claim: it feeds `gettextCatalog` a French catalog, switches language, and asserts the label becomes "Se connecter" while `.ladda-button` and `.ladda-spinner` are still intact. It passes. There is no gettext conflict.

Three runs with `npm run test:component` (karma + jasmine + headless Chrome, the same job CI runs):

- **Red A**, both source changes reverted: 94 executed, the 5 new ones fail.
- **Red B**, template enabled but shim reverted: 94 executed, the same 5 fail with `TypeError: Ladda.create is not a function`.
- **Green**, both changes: 94/94 pass.

master is at 90/90, so this is a net +4: five new specs replacing the one placeholder.

`eslint` reports 0 errors and 0 warnings.

Protractor was not used here: those specs need a live STF with real devices, so they cannot run in CI.

## Checked in a running STF

`bin/stf local`, with the real bundled CSS. The control pane route could not be used because a fake device is never `usable`, so STF bounces you back to the device list. Instead the real `store-account.pug` was compiled into the live app through its own injector, which means the same stylesheet, the same `angular-ladda` directive and the same template as production.

| | idle | `addingAccount = true` | settled |
| --- | --- | --- | --- |
| button classes | `... ladda-button` | `... ladda-button` | `... ladda-button` |
| `data-loading` | absent | present | absent |
| `.ladda-spinner` children | 0 | 1 | 0 |
| `.ladda-label` text | `Sign In` | `Sign In` | `Sign In` |
| button width | 77px | 123px | 77px |

The 77 → 123 → 77 width change is the `expand-left` animation making room for the spinner and then releasing it. The spinner renders in the `#157afb` given by `data-spinner-color`, to the left of the label, and there is exactly one of it now that the `fa-spinner` stand-in is gone. The button reads greyed out in the screenshot because `ng-disabled='storeLogin.$invalid'` holds while the credential fields are empty, which is unrelated to this change.

