### PR TITLE
Wait for control instead of retrying on a timer in RemoteDebugCtrl

### DIFF
--- a/res/app/control-panes/dashboard/remote-debug/remote-debug-controller.js
+++ b/res/app/control-panes/dashboard/remote-debug/remote-debug-controller.js
@@ -1,26 +1,19 @@
-module.exports = function RemoteDebugCtrl($scope, $timeout, gettext) {
+module.exports = function RemoteDebugCtrl($scope, gettext) {
   function startRemoteConnect() {
-    if ($scope.control) {
-      $scope.control.startRemoteConnect().then(function(result) {
-        var url = result.lastData
-        $scope.$apply(function() {
-          $scope.debugCommand = 'adb connect ' + url
-        })
+    $scope.control.startRemoteConnect().then(function(result) {
+      var url = result.lastData
+      $scope.$apply(function() {
+        $scope.debugCommand = 'adb connect ' + url
       })
+    })
+  }
 
-      return true
+  var stopWaitingForControl = $scope.$watch('control', function(control) {
+    if (control) {
+      stopWaitingForControl()
+      startRemoteConnect()
     }
-    return false
-  }
-
-  // TODO: Remove timeout and fix control initialization
-  if (!startRemoteConnect()) {
-    $timeout(function() {
-      if (!startRemoteConnect()) {
-        $timeout(startRemoteConnect, 1000)
-      }
-    }, 200)
-  }
+  })
 
   $scope.$watch('platform', function(newValue) {
     if (newValue === 'native') {

--- a/res/app/control-panes/dashboard/remote-debug/remote-debug-spec.js
+++ b/res/app/control-panes/dashboard/remote-debug/remote-debug-spec.js
@@ -1,14 +1,105 @@
 describe('RemoteDebugCtrl', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope
+  var scope, controller, timeout, settle
 
-  beforeEach(inject(function($rootScope, $controller) {
+  beforeEach(inject(function($rootScope, $controller, $timeout) {
     scope = $rootScope.$new()
-    $controller('RemoteDebugCtrl', {$scope: scope})
+    timeout = $timeout
+    settle = null
+    controller = function() {
+      $controller('RemoteDebugCtrl', {$scope: scope})
+    }
   }))
 
-  it('should ...', inject(function() {
-    expect(1).toEqual(1)
-  }))
+  // the real control returns a socket promise, so it settles outside any digest
+  function control(url) {
+    return {
+      startRemoteConnect: function() {
+        return {
+          then: function(callback) {
+            settle = function() {
+              callback({lastData: url})
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it('should ask for the connect url when control is there already', function() {
+    scope.control = control('10.0.0.1:5555')
+
+    controller()
+    scope.$digest()
+    settle()
+
+    expect(scope.debugCommand).toEqual('adb connect 10.0.0.1:5555')
+  })
+
+  it('should wait for control rather than guessing when it will arrive', function() {
+    controller()
+    scope.$digest()
+
+    expect(settle).toBeNull()
+
+    scope.control = control('10.0.0.2:5555')
+    scope.$digest()
+    settle()
+
+    expect(scope.debugCommand).toEqual('adb connect 10.0.0.2:5555')
+  })
+
+  // control can take longer to arrive than any fixed retry ladder allows for
+  it('should still connect when control shows up late', function() {
+    controller()
+    scope.$digest()
+
+    timeout.flush(5000)
+
+    scope.control = control('10.0.0.3:5555')
+    scope.$digest()
+    settle()
+
+    expect(scope.debugCommand).toEqual('adb connect 10.0.0.3:5555')
+  })
+
+  it('should not leave a timer pending when control never arrives', function() {
+    controller()
+    scope.$digest()
+
+    expect(function() {
+      timeout.verifyNoPendingTasks()
+    }).not.toThrow()
+  })
+
+  it('should ask only once even if control is replaced later', function() {
+    var calls = 0
+    var counting = {
+      startRemoteConnect: function() {
+        calls++
+        return {then: function() {}}
+      }
+    }
+
+    controller()
+    scope.control = counting
+    scope.$digest()
+    scope.control = angular.extend({}, counting)
+    scope.$digest()
+
+    expect(calls).toEqual(1)
+  })
+
+  it('should describe the command differently for native and browser', function() {
+    controller()
+
+    scope.platform = 'native'
+    scope.$digest()
+    expect(scope.remoteDebugTooltip).toMatch('from your IDE')
+
+    scope.platform = 'browser'
+    scope.$digest()
+    expect(scope.remoteDebugTooltip).toMatch('from your Browser')
+  })
 })


### PR DESCRIPTION
Closes the `// TODO: Remove timeout and fix control initialization` in `remote-debug-controller.js`.

The controller asked `$scope.control` for the connect url the moment it was constructed, and when control was not there yet it guessed:

```js
if (!startRemoteConnect()) {
  $timeout(function() {
    if (!startRemoteConnect()) {
      $timeout(startRemoteConnect, 1000)
    }
  }, 200)
}
```

`ControlPanesCtrl` only assigns `$scope.control` after `DeviceService.get` and `GroupService.invite` have both resolved, so how long that takes is a server round trip plus a device invite. A fixed ladder cannot be right about that. Miss the last rung and the Remote debug widget stays empty for the life of the pane, with no further retry.

A `$watch` does the same job without guessing, and deregisters itself on the first control that arrives so a later reassignment cannot fire a second `startRemoteConnect`:

```js
var stopWaitingForControl = $scope.$watch('control', function(control) {
  if (control) {
    stopWaitingForControl()
    startRemoteConnect()
  }
})
```

`$timeout` is no longer injected.

## Tests

The stub spec is replaced with six. Four fail against the old controller:

| Spec | Fails on master |
| --- | --- |
| should ask for the connect url when control is there already | no (regression guard) |
| should wait for control rather than guessing when it will arrive | yes |
| should still connect when control shows up late | yes |
| should not leave a timer pending when control never arrives | yes |
| should ask only once even if control is replaced later | yes |
| should describe the command differently for native and browser | no (regression guard) |

The last two red ones are the retries themselves: master leaves a pending `$timeout` when control never arrives, and calls `startRemoteConnect` a second time on a control that was already connected.

The control stub settles through a plain thenable the spec triggers by hand, because the real `startRemoteConnect` returns a socket promise that settles outside any digest. That is what the `$scope.$apply` in the callback is there for, and keeping it outside a digest in the spec keeps that `$apply` valid.

`npm run test:component`: with the old controller restored and these specs in place, 99 run and
exactly the 4 marked above fail. With the fix, 99/99 pass. master is at 94/94, so this is a net +5:
six new specs replacing the one stub. `eslint` reports 0 errors and 0 warnings.

## Measured in a running STF

`bin/stf local` on master and on this branch, driven through the Chrome DevTools Protocol. The real `remote-debug.pug` is compiled into the live app through its own injector, and `control` is assigned at 2.5s, past both rungs of master's ladder. No `$timeout.flush()`, real wall-clock timing, real digest cycle.

| | master | this branch |
| --- | --- | --- |
| textarea after 4.5s | empty | `adb connect 10.9.9.9:5555` |

The widget renders the command in the real page on this branch and stays blank on master, which is the failure the TODO is about.

