### PR TITLE
Stop the uninstall button opening the accordion it sits in

### DIFF
--- a/res/app/control-panes/dashboard/install/install-controller.js
+++ b/res/app/control-panes/dashboard/install/install-controller.js
@@ -25,8 +25,14 @@ module.exports = function InstallCtrl(
     return null
   }
 
-  $scope.uninstall = function(packageName) {
-    // TODO: After clicking uninstall accordion opens
+  $scope.uninstall = function(packageName, $event) {
+    if ($event) {
+      // the button is transcluded into the accordion heading's own anchor, which
+      // both toggles the panel and, with an empty href, reloads the page
+      $event.preventDefault()
+      $event.stopPropagation()
+    }
+
     return $scope.control.uninstall(packageName)
       .then(function() {
         $scope.$apply(function() {

--- a/res/app/control-panes/dashboard/install/install-spec.js
+++ b/res/app/control-panes/dashboard/install/install-spec.js
@@ -1,14 +1,125 @@
 describe('InstallCtrl', function() {
+  beforeEach(angular.mock.module(require('ui-bootstrap').name))
   beforeEach(angular.mock.module(require('./').name))
 
-  var scope
+  var scope, compile, templates, element, ctrlScope, uninstalled
 
-  beforeEach(inject(function($rootScope, $controller) {
+  beforeEach(inject(function($rootScope, $compile, $templateCache) {
     scope = $rootScope.$new()
-    $controller('InstallCtrl', {$scope: scope})
+    compile = $compile
+    templates = $templateCache
+    uninstalled = []
+    scope.control = {
+      uninstall: function(packageName) {
+        uninstalled.push(packageName)
+        return {then: function() {}}
+      }
+    }
   }))
 
-  it('should ...', inject(function() {
-    expect(1).toEqual(1)
-  }))
+  afterEach(function() {
+    if (element) {
+      element.remove()
+      element = null
+    }
+  })
+
+  function installed() {
+    return {
+      state: 'installed'
+      , settled: true
+      , success: true
+      , progress: 100
+      , manifest: {
+        package: 'com.example.app'
+        , application: {activities: []}
+      }
+    }
+  }
+
+  // the widget root carries ng-controller, so installation lives on its child scope
+  function build(installation) {
+    element = compile(
+      templates.get('control-panes/dashboard/install/install.pug'))(scope)
+    document.body.appendChild(element[0])
+    scope.$digest()
+    ctrlScope = element.scope()
+    ctrlScope.installation = installation
+    ctrlScope.$digest()
+
+    // accordion-group pulls its template through $templateRequest, so it lands a digest later
+    ctrlScope.$digest()
+    return element[0]
+  }
+
+  function uninstallButton() {
+    return element[0].querySelector('button[ng-click^="uninstall"]')
+  }
+
+  function heading() {
+    return element[0].querySelector('.accordion-toggle')
+  }
+
+  // ng-if gives the accordion its own child scope, so accordionOpen written back
+  // through is-open lands there and not on the controller's. The group's own
+  // isolate scope is the one that says whether the panel is open.
+  function group() {
+    return angular.element(element[0].querySelector('.panel')).isolateScope()
+  }
+
+  function setOpen(value) {
+    group().isOpen = value
+    ctrlScope.$digest()
+  }
+
+  it('should offer an uninstall button once an app is installed', function() {
+    build(installed())
+
+    expect(uninstallButton()).not.toBeNull()
+  })
+
+  it('should uninstall the installed package when the button is clicked', function() {
+    build(installed())
+
+    uninstallButton().click()
+
+    expect(uninstalled).toEqual(['com.example.app'])
+  })
+
+  // the button is transcluded into the group's own ng-click='toggleOpen()' anchor
+  it('should leave a collapsed accordion alone when uninstall is clicked', function() {
+    build(installed())
+    setOpen(false)
+
+    uninstallButton().click()
+
+    expect(group().isOpen).toBe(false)
+  })
+
+  it('should leave an open accordion alone when uninstall is clicked', function() {
+    build(installed())
+    setOpen(true)
+
+    uninstallButton().click()
+
+    expect(group().isOpen).toBe(true)
+  })
+
+  it('should still toggle when the heading itself is clicked', function() {
+    build(installed())
+    setOpen(false)
+
+    heading().click()
+
+    expect(group().isOpen).toBe(true)
+  })
+
+  it('should drop the installation and collapse the accordion on clear', function() {
+    build(installed())
+
+    ctrlScope.clear()
+
+    expect(ctrlScope.installation).toBeNull()
+    expect(ctrlScope.accordionOpen).toBe(false)
+  })
 })

--- a/res/app/control-panes/dashboard/install/install.pug
+++ b/res/app/control-panes/dashboard/install/install.pug
@@ -48,7 +48,8 @@
                   span  {{installation.manifest.package || "App" }}
 
                   button.btn.btn-xs.btn-danger-outline.pull-right(
-                  ng-click='uninstall(installation.manifest.package)', ng-show='installation.success')
+                  ng-click='uninstall(installation.manifest.package, $event)',
+                  ng-show='installation.success')
                     i.fa.fa-trash-o
                     span(translate) Uninstall
                 div(ng-include='"control-panes/dashboard/install/activities/activities.pug"')


### PR DESCRIPTION
Closes the `// TODO: After clicking uninstall accordion opens` in `install-controller.js`.

`install.pug` puts the Uninstall button inside `accordion-heading`, and ui-bootstrap transcludes that heading into the accordion group's own anchor. The rendered DOM is:

```html
<a href="" class="accordion-toggle" ng-click="toggleOpen()"
   uib-accordion-transclude="heading">
  <i class="fa fa-file-o"></i>
  <span> com.example.app</span>
  <button ng-click="uninstall(...)">Uninstall</button>
</a>
```

So the click lands on the button and then keeps going up to the anchor, which toggles the panel. Uninstall from a collapsed accordion and it springs open on the way out. That is exactly what the TODO describes.

## `stopPropagation` alone reloads the page

My first attempt was `$event.stopPropagation()` in the template. It fixed the toggle and broke something worse: karma started reporting

```
Some of your tests did a full page reload!
```

The anchor's `href` is empty, and it is angular's own `a[href]` directive that keeps an empty href from navigating. Stopping propagation means the event never reaches that handler, so the browser follows the empty href and reloads. Both calls are needed, so `$event` is passed through to the controller instead of doing it inline:

```js
$scope.uninstall = function(packageName, $event) {
  if ($event) {
    $event.preventDefault()
    $event.stopPropagation()
  }
  return $scope.control.uninstall(packageName)...
```

## Tests

The stub spec is replaced with six that compile the real `install.pug` with `ui-bootstrap` loaded. Two fail against the old template:

| Spec | Fails on master |
| --- | --- |
| should offer an uninstall button once an app is installed | no |
| should uninstall the installed package when the button is clicked | no |
| should leave a collapsed accordion alone when uninstall is clicked | yes |
| should leave an open accordion alone when uninstall is clicked | yes |
| should still toggle when the heading itself is clicked | no |
| should drop the installation and collapse the accordion on clear | no |

"should still toggle when the heading itself is clicked" earns its place: without it the two red specs could pass for the wrong reason, and during development they did. Two things had to be right first.

`accordion-group` pulls its template through `$templateRequest`, so it lands a digest after the one that renders `ng-if='installation'`. One digest short and the heading markup does not exist at all, so nothing toggles and the assertions pass vacuously.

Assertions are on the group's isolate scope, not on `accordionOpen`. `ng-if` gives the accordion a child scope, so the value written back through `is-open` shadows the controller's copy and never reaches it. Reading `ctrlScope.accordionOpen` shows `false` no matter what the panel does.

The fixture needs `manifest.application.activities` because `ActivitiesCtrl` watches `installation.manifest.application` and reads `newValue.activities` with no guard. Not touched here, but it will throw on any manifest without an `application`.

`npm run test:component`: master is at 99/99, this branch is 104/104. With the old controller and
template restored and these specs kept, 104 run and exactly the 2 accordion specs above fail.
`eslint` reports 0 errors and 0 warnings.

## Measured in a running STF

`bin/stf local` on master and on this branch, driven through the Chrome DevTools Protocol. The real `install.pug` is compiled into the live app through its own injector, the panel is collapsed, and the Uninstall button is clicked with real `Input.dispatchMouseEvent` presses rather than a synthetic `click()`.

| | master | this branch |
| --- | --- | --- |
| panel open before the click | `false` | `false` |
| panel open after the click | `true` | `false` |
| `control.uninstall` called | `['com.example.app']` | `['com.example.app']` |
| page reloaded | no | no |

So the accordion springs open on master and stays put here, with the uninstall itself unaffected. The anchor's `href` reads as `""` in the live DOM, which is the empty href that `preventDefault` is there for.

