### PR TITLE
Move the version update wiring out of the socket factory

### DIFF
--- a/res/app/components/stf/common-ui/modals/version-update/version-update-spec.js
+++ b/res/app/components/stf/common-ui/modals/version-update/version-update-spec.js
@@ -1,10 +1,54 @@
 describe('VersionUpdateService', function() {
-  beforeEach(angular.mock.module(require('ui-bootstrap').name))
   beforeEach(angular.mock.module(require('./').name))
 
-  it('should ...', inject(function() {
+  var service, modal, location
 
-	// expect(VersionUpdateService.doSomething()).toEqual('something');
-
+  beforeEach(inject(function(VersionUpdateService, $uibModal, $location) {
+    service = VersionUpdateService
+    modal = $uibModal
+    location = $location
   }))
+
+  // the modal controller is a plain function on the options object, so the spec
+  // runs it directly instead of standing up a modal instance
+  function openWith(instance) {
+    var opened
+    spyOn(modal, 'open').and.callFake(function(options) {
+      opened = options
+      return {result: {then: angular.noop}}
+    })
+    service.open()
+
+    var scope = {}
+    opened.controller(scope, instance)
+    return scope
+  }
+
+  it('should open a modal', function() {
+    openWith({})
+
+    expect(modal.open).toHaveBeenCalled()
+  })
+
+  it('should send the user home when the modal is confirmed', function() {
+    var instance = {close: jasmine.createSpy('close')}
+    openWith(instance).ok()
+
+    expect(instance.close).toHaveBeenCalledWith(true)
+    expect(location.path()).toEqual('/')
+  })
+
+  it('should dismiss the modal when it is cancelled', function() {
+    var instance = {dismiss: jasmine.createSpy('dismiss')}
+    openWith(instance).cancel()
+
+    expect(instance.dismiss).toHaveBeenCalledWith('cancel')
+  })
+
+  // the wiring used to live in the socket factory, which made stf.socket depend
+  // on this modal
+  it('should not be a dependency of stf.socket', function() {
+    expect(angular.module(require('stf/socket').name).requires)
+      .not.toContain(require('./').name)
+  })
 })

--- a/res/app/components/stf/socket/index.js
+++ b/res/app/components/stf/socket/index.js
@@ -1,6 +1,4 @@
 module.exports = angular.module('stf.socket', [
-  // TODO: Refactor version update out to its own Ctrl
   require('stf/app-state').name
-  , require('stf/common-ui/modals/version-update').name
 ])
   .factory('socket', require('./socket-service'))

--- a/res/app/components/stf/socket/socket-service.js
+++ b/res/app/components/stf/socket/socket-service.js
@@ -6,7 +6,6 @@ var io = require('socket.io-client').io
 
 module.exports = function SocketFactory(
   $rootScope
-, VersionUpdateService
 , AppState
 ) {
   var websocketUrl = AppState.config.websocketUrl || ''
@@ -33,10 +32,6 @@ module.exports = function SocketFactory(
       }
     }
   }
-
-  socket.on('outdated', function() {
-    VersionUpdateService.open()
-  })
 
   socket.on('socket.ip', function(ip) {
     $rootScope.$apply(function() {

--- a/res/app/components/stf/socket/socket-state/index.js
+++ b/res/app/components/stf/socket/socket-state/index.js
@@ -4,6 +4,7 @@ module.exports = angular.module('stf/socket/socket-state', [
   , require('stf/common-ui/notifications').name
   , require('stf/common-ui/refresh-page').name
   , require('stf/common-ui/modals/socket-disconnected').name
+  , require('stf/common-ui/modals/version-update').name
 ])
   .directive('socketState', require('./socket-state-directive'))
   .config([

--- a/res/app/components/stf/socket/socket-state/socket-state-directive.js
+++ b/res/app/components/stf/socket/socket-state/socket-state-directive.js
@@ -4,6 +4,7 @@ module.exports = function SocketStateDirectiveFactory(
 , gettext
 , $filter
 , SocketDisconnectedService
+, VersionUpdateService
 , $window
 ) {
   return {
@@ -72,6 +73,9 @@ module.exports = function SocketStateDirectiveFactory(
       , reconnect: function() {
           setState('reconnect')
           hasFailedOnce = true
+        }
+      , outdated: function() {
+          VersionUpdateService.open()
         }
       }
 

--- a/res/app/components/stf/socket/socket-state/socket-state-spec.js
+++ b/res/app/components/stf/socket/socket-state/socket-state-spec.js
@@ -1,0 +1,32 @@
+describe('socketState', function() {
+  // the directive injects gettext, which the module has always left to app.js
+  beforeEach(angular.mock.module(require('gettext').name))
+  beforeEach(angular.mock.module(require('./').name))
+
+  var socket, versionUpdate, element
+
+  beforeEach(inject(function($compile, $rootScope, _socket_, VersionUpdateService) {
+    socket = _socket_
+    versionUpdate = VersionUpdateService
+    element = $compile('<socket-state></socket-state>')($rootScope.$new())
+    $rootScope.$digest()
+  }))
+
+  afterEach(function() {
+    element.remove()
+  })
+
+  // being in the directive's socketListeners map is also what gets outdated the
+  // same beforeunload cleanup the other socket events already had
+  it('should listen for outdated alongside the other socket states', function() {
+    expect(socket.listeners('outdated').length).toEqual(1)
+    expect(socket.listeners('disconnect').length).toEqual(1)
+  })
+
+  it('should open the version update modal when the client is outdated', function() {
+    spyOn(versionUpdate, 'open')
+    socket.listeners('outdated')[0]()
+
+    expect(versionUpdate.open).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes the `// TODO: Refactor version update out to its own Ctrl` in `stf/socket/index.js`.

The socket module depended on the version update modal purely so the transport factory could open
it:

```js
module.exports = function SocketFactory($rootScope, VersionUpdateService, AppState) {
  ...
  socket.on('outdated', function() {
    VersionUpdateService.open()
  })
```

That puts app level UI inside a transport factory, and makes `stf.socket` depend on a modal it has
no other use for. Anything wanting a socket drags the modal in with it.

## Where it goes instead

The `socketState` directive already does this exact job for the socket disconnected modal. It keeps
a `socketListeners` map of event to handler, registers the lot on link, and tears them down on
`beforeunload`:

```js
      , reconnect: function() {
          setState('reconnect')
          hasFailedOnce = true
        }
+     , outdated: function() {
+         VersionUpdateService.open()
+       }
      }
```

So `outdated` joins the map. The version update modal stays passive, exactly like the socket
disconnected modal, and the listener inherits the existing cleanup rather than needing its own.

## Why not a run block in the modal module

That was the first version of this change, and it is wrong in a way worth writing down.

Both auth entries pull `stf/common-ui`, which reaches `stf.modals` and so the version update modal.
Giving that modal a `stf/socket` dependency therefore puts socket.io in the login bundles, and a
`run` block would instantiate the socket at bootstrap, where `socket-service.js` calls
`io(websocketUrl)` with `AppState.config.websocketUrl` defaulting to `''`. The unauthenticated login
page would open a websocket to the origin.

Both halves measured, by building it that way and loading `/auth/mock/` in a real browser:

| | socket.io chunk | loaded by | websocket on the login page |
| --- | --- | --- | --- |
| run block in the modal module | 6 | `app`, **`authmock`**, **`authldap`** | `ws://127.0.0.1:7100/socket.io/?EIO=4&transport=websocket` |
| this branch | 4 | `app` only | none, `window.io` is `undefined` |

`socket-state` is only reachable from `layout`, so putting the wiring there keeps the auth bundles
exactly as they are.

## Tests

The placeholder spec is replaced with four, and the directive gets three new ones.

Only one is red against master, and that is the honest summary: the two directive specs pass on
master too, because master registers the same listener from the socket factory. They are there to
prove the behaviour is unchanged by the move.

| Spec | Fails on master |
| --- | --- |
| VersionUpdateService should open a modal | no |
| VersionUpdateService should send the user home when the modal is confirmed | no |
| VersionUpdateService should dismiss the modal when it is cancelled | no |
| VersionUpdateService should not be a dependency of stf.socket | yes |
| socketState should listen for outdated alongside the other socket states | no (regression guard) |
| socketState should open the version update modal when the client is outdated | no (regression guard) |

`npm run test:component`: master is at 104/104, this branch is 109/109. With master's sources
restored and these specs kept, 109 run and 1 fails. `eslint` reports 0 errors and 0 warnings.

## Measured in a running STF

`bin/stf local` on master and on this branch, driven over the Chrome DevTools Protocol. The listener
count is read off the live socket and the modal is opened by invoking the registered handler.

| | master | this branch |
| --- | --- | --- |
| `socket.listeners('outdated').length` | 1 | 1 |
| firing that listener opens the modal | yes | yes |
| `injector.has('VersionUpdateService')` | true | true |
| socket connected | yes | yes |
| websocket on `/auth/mock/` | none | none |

Identical behaviour on both sides is the result being checked. The listener moved from the socket
factory to the socket state directive and nothing a user sees changed.

