### PR TITLE
Report an emulator teardown hang as a warning, not a silent timeout

### DIFF
--- a/.github/scripts/android-verdict.js
+++ b/.github/scripts/android-verdict.js
@@ -21,37 +21,48 @@ function main() {
 
   var status
   var details
+  var outcome = process.env.EMULATOR_OUTCOME || ''
+  var gating = layers.LAYERS.filter(function(layer) {
+    return layer.gating
+  })
+  var failed = gating.filter(function(layer) {
+    return checks[layer.key] === 'fail'
+  })
+  // Anything that is not an explicit pass counts as unreached, not just "skip".
+  // A gating key that is missing entirely means the seed never landed, and
+  // treating that as satisfied would report a leg green having done nothing.
+  var unreached = gating.filter(function(layer) {
+    return checks[layer.key] !== 'pass' && checks[layer.key] !== 'fail'
+  })
+  // Read before the teardown write below, which would otherwise make an empty
+  // checks.json look populated.
+  var nothingRan = !Object.keys(checks).length
+
+  // Teardown is the one layer the leg cannot record, because it happens after
+  // the script exits. A step that did not exit cleanly having already passed
+  // everything hung on the way out; anything else is named by the verdict below,
+  // and blaming teardown too would misattribute the same failure twice.
+  checks.teardown = outcome === 'success' ? 'pass' :
+    (!failed.length && !unreached.length &&
+      (outcome === 'failure' || outcome === 'cancelled')) ? 'warn' : 'skip'
 
   if (checks.image === 'skip') {
     status = 'skip'
     details = 'no published system image for API ' +
       (process.env.ANDROID_API || '?') + ' ' + (process.env.ANDROID_ARCH || '')
   }
-  else if (!Object.keys(checks).length) {
+  else if (nothingRan) {
     // The leg script seeds every check before it does anything, so no checks at
     // all means the emulator step never handed control over: AVD creation or
     // boot ran out the clock.
     status = 'fail'
     details = 'the emulator never finished booting, so nothing ran against it' +
-      (process.env.EMULATOR_OUTCOME
-        ? ' (emulator step: ' + process.env.EMULATOR_OUTCOME + ')'
-        : '')
+      (outcome ? ' (emulator step: ' + outcome + ')' : '')
   }
   else {
-    var gating = layers.LAYERS.filter(function(layer) {
-      return layer.gating
-    })
-    var failed = gating.filter(function(layer) {
-      return checks[layer.key] === 'fail'
-    })
-    // Anything that is not an explicit pass counts as unreached, not just
-    // "skip". A gating key that is missing entirely means the seed never landed,
-    // and treating that as satisfied would report a leg green having done nothing.
-    var unreached = gating.filter(function(layer) {
-      return checks[layer.key] !== 'pass' && checks[layer.key] !== 'fail'
-    })
     var softFailed = layers.LAYERS.filter(function(layer) {
-      return !layer.gating && checks[layer.key] === 'fail'
+      return !layer.gating &&
+        (checks[layer.key] === 'fail' || checks[layer.key] === 'warn')
     })
 
     if (failed.length) {
@@ -90,6 +101,11 @@ function main() {
   , 'details=' + details.replace(/\r?\n/g, ' ')
   , 'extra=' + JSON.stringify(extra)
   ].join('\n') + '\n'
+
+  if (checks.teardown === 'warn') {
+    process.stdout.write('::warning::Android ' + extra.android + ' (API ' +
+      extra.api + ') passed every check, then hung in emulator teardown\n')
+  }
 
   if (process.env.GITHUB_OUTPUT) {
     fs.appendFileSync(process.env.GITHUB_OUTPUT, out)

--- a/.github/scripts/checks.js
+++ b/.github/scripts/checks.js
@@ -1,9 +1,13 @@
 //
-// The layered device checks, most fundamental first, in one place.
+// The per-leg check columns, in the order a leg proves them, in one place.
 //
 // The order is semantic: android-verdict.js names the deepest layer that broke
 // by walking it, and render-report.js renders one table column per entry in the
 // same order. Splitting the list across files let the two disagree.
+//
+// The first eight are device capability, most fundamental first. `teardown` is
+// last because it is about the runner rather than the device, and it is only
+// knowable once the leg script has exited.
 //
 // usage: node checks.js seed <checks.json>
 //
@@ -85,6 +89,14 @@ var LAYERS = [
   , gating: true
   , failure: 'the web UI suite failed'
   , blurb: 'the rest of the Playwright web UI suite'
+  }
+, {
+    key: 'teardown'
+  , label: 'Teardown'
+  , seed: 'skip'
+  , gating: false
+  , failure: 'the emulator step did not exit cleanly after every check had passed'
+  , blurb: 'the emulator action shut the AVD down and exited on its own'
   }
 ]
 

--- a/.github/scripts/render-report.js
+++ b/.github/scripts/render-report.js
@@ -19,6 +19,7 @@ var ICON = {
 var CHECK_ICON = {
   pass: ':white_check_mark:'
 , fail: ':x:'
+, warn: ':warning:'
 , skip: ':heavy_minus_sign:'
 , 'n/a': ':heavy_minus_sign:'
 }


### PR DESCRIPTION
On #922 the Android 15 leg passed every check in 30 seconds and then sat in the emulator action for
another 46 minutes until the 50 minute step cap fired.

```
12:25:42  step starts
12:29:10  Installing STFService
12:29:35  last log line, all 8 checks pass, device present/ready/usable
~13:15:42 step hits its 50 minute cap, "has timed out after 50 minutes"
13:18:01  job completes, verdict pass
```

The verdict was right. It comes from `checks.json`, not from the step outcome, so a leg that proved
the device works reports green even when the action does not exit cleanly. But the run showed a red
timeout inside a green job and nothing distinguished the two cases that produce it: a hang *before*
the device was proven, and a hang *after*.

## What changes

Teardown becomes its own non-gating layer. It is the one layer the leg script cannot record, since
it happens after the script exits, so `android-verdict.js` derives it from the emulator step's
outcome:

| emulator step | gating layers | `teardown` |
| --- | --- | --- |
| exited cleanly | any | `pass` |
| did not exit | all passed | **`warn`** |
| did not exit | something broke | `skip` |

That last row matters: blaming teardown when the real failure was earlier would report the same
problem twice and bury the actual cause.

`warn` is a new check status. It renders `:warning:` instead of `:x:`, because a teardown hang costs
runner minutes and says nothing about the device. The leg stays green, the details line picks up the
existing soft-failure suffix, and the verdict step emits a `::warning::` naming what happened.

## What this does not do

The `The action 'Boot the emulator and run STF against it' has timed out after 50 minutes` line is
emitted by the GitHub Actions runner itself when a step's `timeout-minutes` fires. A workflow cannot
suppress it or lower its level, so it will still appear. What this PR does is make everything around
it say the right thing: green job, green leg, an explicit warning annotation, and a Teardown column
that shows which legs hung on the way out.

I also left `timeout-minutes: 50` and the emulator action alone. The ask here is indication and
severity, not preventing the hang.

## Verified

`android-verdict.js` is a pure function of `checks.json` plus environment, so every branch is
exercised directly. The first row is the real incident replayed: the actual `checks.json` artifact
downloaded from the #922 run, fed back through the new code.

| case | `status` | `teardown` | `::warning::` |
| --- | --- | --- | --- |
| all pass + step failure (the #922 incident) | `pass` | `warn` | yes |
| all pass + clean exit | `pass` | `pass` | no |
| empty checks + failure (a real boot hang) | `fail` | `skip` | no |
| a gating layer failed + failure | `fail` | `skip` | no |
| unpublished image | `skip` | `skip` | no |

Rendered report, the same two legs side by side:

```
|  | Android | API | Image | Boot | In STF | Usable | Screen | Touch | Shell | UI E2E | Teardown |
| :white_check_mark: | 14 | 34 | ... | :white_check_mark: | :white_check_mark: |
| :white_check_mark: | 15 | 35 | ... | :white_check_mark: | :warning:            |
```

and the details line for that leg reads:

```
usable device, screen streaming, touch confirmed on the device
  (but the emulator step did not exit cleanly after every check had passed)
```

`eslint` reports 0 errors and 0 warnings. Nothing under `res/` or `lib/` changes, so the component
suite is untouched.

