### PR TITLE
Add Android 16.1 and 17 legs by updating cmdline-tools

### DIFF
--- a/.github/android-matrix.json
+++ b/.github/android-matrix.json
@@ -21,9 +21,19 @@
     "usable: minitouch 1.3.2 cannot link on 4.x, and 4.1 additionally crashes",
     "STFService. Both were measured, see doc/ci.md.",
     "",
-    "Android 17 (API 37.0) is parked at the other end, not forgotten: the",
-    "emulator boots and STF claims the device, then STFService will not start on",
-    "it. See doc/ci.md."
+    "The minor-versioned levels 36.1 and 37.x need the cmdline-tools update in",
+    "ci.yml: the runner image ships 12.0, which cannot parse a dotted api like",
+    "37.1 and writes target=android-0 into the AVD. See doc/ci.md.",
+    "",
+    "target for those rows: the AOSP repo stops at android-36;default, so 36.1",
+    "and 37.x have no `default` image. 36.1 and 37.0 have a plain google_apis",
+    "one; 37.1 and 37.2 ship only the 16 KB page size variant. No playstore",
+    "variant is usable here because they block adb root, which minitouch needs.",
+    "",
+    "37.2 is published only on the dev SDK channel, hence its channel key.",
+    "--channel is cumulative, so the stable legs are unaffected. The 37.2 betas",
+    "are deliberately excluded: GA supersedes them, and Google prunes beta",
+    "images after GA, which would make the leg self-skip green with no coverage."
   ],
   "include": [
     {"android": "5.0", "api": "21", "target": "default", "arch": "x86", "boot": 900},
@@ -41,6 +51,10 @@
     {"android": "13", "api": "33", "target": "default", "arch": "x86_64", "boot": 720},
     {"android": "14", "api": "34", "target": "default", "arch": "x86_64", "boot": 720},
     {"android": "15", "api": "35", "target": "default", "arch": "x86_64", "boot": 720},
-    {"android": "16", "api": "36", "target": "default", "arch": "x86_64", "boot": 720}
+    {"android": "16", "api": "36", "target": "default", "arch": "x86_64", "boot": 720},
+    {"android": "16.1", "api": "36.1", "target": "google_apis", "arch": "x86_64", "boot": 720},
+    {"android": "17", "api": "37.0", "target": "google_apis", "arch": "x86_64", "boot": 900},
+    {"android": "17", "api": "37.1", "target": "google_apis_ps16k", "arch": "x86_64", "boot": 900},
+    {"android": "17", "api": "37.2", "target": "google_apis_ps16k", "arch": "x86_64", "boot": 900, "channel": "dev"}
   ]
 }

--- a/.github/scripts/update-cmdline-tools.sh
+++ b/.github/scripts/update-cmdline-tools.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# ubuntu-24.04 ships Android cmdline-tools 12.0, which cannot parse a dotted API
+# level. avdmanager then writes `target=android-0` into the AVD instead of
+# `target=android-37.1`, which mis-configures gfxstream: the guest is offered
+# ReadColorBufferDma and mapper.ranchu SIGABRTs, taking SurfaceFlinger with it.
+# See https://issuetracker.google.com/issues/546200928 and
+# https://github.com/actions/runner-images/issues/14484.
+#
+# `latest` is replaced in place on purpose. android-emulator-runner puts
+# $ANDROID_HOME/cmdline-tools/latest on PATH and invokes a bare `avdmanager`, so
+# the sibling `latest-2` that `sdkmanager --install "cmdline-tools;latest"`
+# creates (it cannot overwrite the directory it is running from) would be
+# ignored and the AVD would still be built by the old tools.
+#
+# Build 16111833 is revision 23, so the pinned build and the floor below agree.
+#
+# This is a workaround with two ways out, and it should be deleted on whichever
+# lands first:
+#   - ReactiveCircus/android-emulator-runner#494 gates the action's own
+#     cmdline-tools install on Pkg.Revision instead of only installing when the
+#     directory is absent, which removes the need for this script entirely.
+#   - actions/runner-images#14484 ships a current cmdline-tools in the image, at
+#     which point the revision check below makes this a no-op on its own.
+#
+set -euo pipefail
+
+BUILD=16111833
+MIN_REVISION=23
+CACHE="${CMDLINE_TOOLS_CACHE:-$HOME/.cache/android-cmdline-tools}"
+SDK="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+[ -n "$SDK" ] || { echo "::error::neither ANDROID_HOME nor ANDROID_SDK_ROOT is set"; exit 1; }
+DEST="$SDK/cmdline-tools/latest"
+
+revision() {
+  sed -n 's/^Pkg.Revision=\([0-9]*\).*/\1/p' "$1/source.properties" 2>/dev/null
+}
+
+present="$(revision "$DEST")"
+echo "cmdline-tools present: ${present:-none}, required: $MIN_REVISION"
+
+if [ -n "$present" ] && [ "$present" -ge "$MIN_REVISION" ]; then
+  echo "already new enough, nothing to do"
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# actions/cache restores $CACHE, so the archive is fetched once per build id and
+# every later leg copies from disk. Copy rather than move, or the first leg
+# empties the cache and there is nothing to save.
+if [ ! -x "$CACHE/cmdline-tools/bin/sdkmanager" ]; then
+  echo "cache miss, downloading build $BUILD"
+  curl -fsSL --retry 3 --retry-delay 5 -o "$work/ct.zip" \
+    "https://dl.google.com/android/repository/commandlinetools-linux-${BUILD}_latest.zip"
+  rm -rf "$CACHE"
+  mkdir -p "$CACHE"
+  unzip -q "$work/ct.zip" -d "$CACHE"
+else
+  echo "cache hit for build $BUILD"
+fi
+
+mkdir -p "$SDK/cmdline-tools"
+rm -rf "$DEST"
+cp -a "$CACHE/cmdline-tools" "$DEST"
+
+echo "cmdline-tools installed: $(revision "$DEST")"
+
+# Revision 23 needs JDK 17 or newer and says so on stderr only, so a discarded
+# stream here turns an actionable error into an empty package listing later.
+if ! "$DEST/bin/avdmanager" list target > /dev/null 2>"$work/err"; then
+  echo "::error::avdmanager is not usable after the update"
+  head -5 "$work/err"
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,24 @@ jobs:
       - name: Wait for RethinkDB
         run: bash .github/scripts/wait-for-port.sh 28015 60 rethinkdb
 
+      # The image ships cmdline-tools 12.0, which cannot parse a dotted API level
+      # and writes target=android-0 into the AVD. That mis-configures gfxstream
+      # and SurfaceFlinger aborts in mapper.ranchu, so every Android 17 leg
+      # fails. A no-op for integer levels. See doc/ci.md.
+      # Only the dotted levels need it, and the archive is 173 MiB, so the 16
+      # integer legs skip the download entirely. API 36 resolves to
+      # target=android-36 under both the shipped and the updated revision.
+      - name: Cache the Android cmdline-tools
+        if: contains(matrix.api, '.')
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/android-cmdline-tools
+          key: cmdline-tools-16111833-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Update the Android cmdline-tools
+        if: contains(matrix.api, '.')
+        run: bash .github/scripts/update-cmdline-tools.sh
+
       # Fresh Android releases are not always published as an x86_64 image yet,
       # so probe instead of hardcoding a matrix that rots.
       - name: Probe for the system image
@@ -515,13 +533,17 @@ jobs:
         run: |
           IMAGE="system-images;android-${{ matrix.api }};${{ matrix.target }};${{ matrix.arch }}"
           echo "looking for $IMAGE"
-          SDKMANAGER="$(ls -d "${ANDROID_HOME:-/usr/local/lib/android/sdk}"/cmdline-tools/*/bin/sdkmanager 2>/dev/null | tail -1)"
+          SDKMANAGER="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}/cmdline-tools/latest/bin/sdkmanager"
+          [ -x "$SDKMANAGER" ] || SDKMANAGER=""
           if [ -z "$SDKMANAGER" ]; then
             echo "::warning::no sdkmanager found, assuming the image exists"
             echo "available=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          "$SDKMANAGER" --list > sdk-packages.txt 2>sdk-packages.err || true
+          # Revision 23 prints package paths slash-separated, so normalise before
+          # matching or every grep below misses and the leg fails open.
+          "$SDKMANAGER" --list --channel=${{ matrix.channel == 'dev' && '2' || '0' }} 2>sdk-packages.err \
+            | tr '/' ';' > sdk-packages.txt || true
           # Fail open. An sdkmanager that errors out produces an empty listing,
           # and treating that as "image not published" would let every leg
           # self-skip and the whole matrix report green with zero coverage.
@@ -559,6 +581,7 @@ jobs:
         with:
           api-level: ${{ matrix.api }}
           target: ${{ matrix.target }}
+          channel: ${{ matrix.channel || 'stable' }}
           arch: ${{ matrix.arch }}
           # Without a device profile avdmanager builds a 320x640 160dpi screen,
           # which is smaller than the browser's device pane, so minicap has to

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -152,25 +152,58 @@ manifest, version 2.5.6, targetSdk 30) and STF only uses PIE binaries from sdk 1
 service, although they do have published x86 images that boot. API 20 is 4.4W
 and only ever shipped for wearables.
 
-### Android 17 (API 37) is parked
+### Minor-versioned levels need current cmdline-tools
 
-Not in the matrix for now. It is an STF limitation, not a CI one: the image
-exists, the emulator boots, the provider registers the device and STF marks it
-present and ready, then the device worker dies in a loop on
-`Service had an error: "Error: Not found; no service started."` plus a
-`PackageManagerInternal.freeStorage` NPE. STFService installs and gets its
-permissions granted, so the on-device service fails to start on API 37 rather
-than failing to install.
+API 36.1 and all three published API 37 levels, 37.0, 37.1 and 37.2, are in the
+matrix. API 37 was parked for a while, and the cause turned out to be the CI
+image rather than STF or the emulator.
 
-To bring it back once STFService supports API 37, add one line to
-`.github/android-matrix.json`:
+`ubuntu-24.04` ships Android cmdline-tools 12.0, which cannot parse a dotted API
+level. `avdmanager create avd --package 'system-images;android-37.1;...'` exits 0
+and writes the correct `image.sysdir.1`, but sets `target=android-0` instead of
+`target=android-37.1`. That mis-configures gfxstream, the guest is offered
+`ReadColorBufferDma`, and `mapper.ranchu.so` aborts:
 
-```json
-{"android": "17", "api": "37.0", "target": "google_apis", "arch": "x86_64", "boot": 900}
+```
+Abort message: 'Assertion failed: !rcEnc->featureInfo()->hasReadColorBufferDma'
+  #03 /vendor/lib64/hw/mapper.ranchu.so  GoldfishMapper::readFromHost(cb_handle_t const&)
+tid: RegionSampling  >>> /system/bin/surfaceflinger <<<  signal 6 (SIGABRT)
 ```
 
-API 37 is published only under the minor-versioned path `37.0` and has no AOSP
-image, so it has to be `google_apis`. Plain `android-37` does not exist.
+SurfaceFlinger then crashloops, `DisplayEventReceiver.nativeInit` fails with
+`status=-32`, `DisplayManagerGlobal.getInstance()` throws, and STFService dies
+reflecting on it. The symptom therefore reads as an STF or STFService bug and is
+not one. Measured before and after, same images, same `-gpu swiftshader_indirect`:
+
+| image | cmdline-tools 12.0 | cmdline-tools 23.0 |
+|---|---|---|
+| `android-37.0;google_apis` | 8 aborts, SF started 4x | 0 aborts, SF started once |
+| `android-37.1;google_apis_ps16k` | 11 aborts, SF started 5x | 0 aborts, SF started once |
+| `android-37.2;google_apis_ps16k` | 11 aborts, SF started 5x | 0 aborts, SF started once |
+
+`.github/scripts/update-cmdline-tools.sh` replaces
+`$ANDROID_HOME/cmdline-tools/latest` in place. It has to be in place:
+android-emulator-runner puts that exact directory on `PATH` and invokes a bare
+`avdmanager`, and `sdkmanager --install "cmdline-tools;latest"` cannot overwrite
+the directory it is running from, so it silently installs to a sibling
+`cmdline-tools/latest-2` that nothing then uses. The update is a no-op for the
+integer levels: API 36 gets `target=android-36` under both 12.0 and 23.0.
+
+On image paths, the AOSP repo stops at `android-36;default`, so neither 36.1 nor
+any API 37 level has a `default` image. 36.1 and 37.0 publish a plain
+`google_apis` one; from `37.1` on Google publishes only the 16 KB page size
+variant, so those legs use `google_apis_ps16k`. Plain `android-37` does not
+exist. No `playstore` variant is usable here, because they block `adb root`,
+which minitouch needs to open `/dev/input`. `37.2` is additionally published only
+on the `dev` SDK channel, which is why its leg carries `channel`/`channelId`;
+`--channel` is cumulative, so the stable legs are unaffected. The 37.2 beta
+images are deliberately left out: GA supersedes them, and Google prunes beta
+images after GA, which would make the leg self-skip and report green with no
+coverage.
+
+Upstream: https://issuetracker.google.com/issues/546200928 (resolved) and
+https://github.com/actions/runner-images/issues/14484 (open, so the update is
+still needed on current images).
 
 ### Rotation control is dead on API 29 and up, and no check catches it
 


### PR DESCRIPTION
Un-parks API 37 and adds API 36.1. The bug was never in STF or the emulator: the runner image ships Android cmdline-tools 12.0, which cannot parse a dotted API level.

`avdmanager create avd --package 'system-images;android-37.1;...'` exits 0 and writes a correct `image.sysdir.1`, but sets `target=android-0` instead of `target=android-37.1`. That mis-configures gfxstream, the guest is offered `ReadColorBufferDma`, and `mapper.ranchu.so` aborts on `Assertion failed: !rcEnc->featureInfo()->hasReadColorBufferDma`. SurfaceFlinger then crash-loops, `DisplayEventReceiver.nativeInit` fails with `status=-32`, and STFService dies reflecting on `DisplayManagerGlobal`. That is why this looked like an STFService bug for so long.

Refs:

* [actions/runner-images#14484](https://github.com/actions/runner-images/issues/14484), still open, so the workaround is still needed on current images.
* [issuetracker.google.com/issues/546200928](https://issuetracker.google.com/issues/546200928), Google's triage identified the tooling cause and resolved it by updating cmdline-tools.

**Fix:** `.github/scripts/update-cmdline-tools.sh` runs before the AVD is created. It replaces `cmdline-tools/latest` in place, and that part matters: android-emulator-runner puts that exact directory on `PATH` and calls a bare `avdmanager`, while `sdkmanager --install "cmdline-tools;latest"` cannot overwrite the directory it is running from, so it quietly installs to a sibling `latest-2` that nothing uses.

| image | cmdline-tools 12.0 | cmdline-tools 23.0 |
|---|---|---|
| `android-37.0;google_apis` | 8 aborts, SurfaceFlinger started 4 times | 0 aborts, started once |
| `android-37.1;google_apis_ps16k` | 11 aborts, started 5 times | 0 aborts, started once |
| `android-37.2;google_apis_ps16k` | 33 aborts, started 28 times | 0 aborts, started once |

Matrix goes from 16 legs to 20, adding 36.1, 37.0, 37.1 and 37.2. All four pass the full 9 checks, identical to the API 36 baseline. The update is a no-op for the integer levels: API 36 gets `target=android-36` under both 12.0 and 23.0.

`doc/ci.md`'s "Android 17 (API 37) is parked" section is rewritten. It attributed the failure to STFService not starting on API 37, and the 37.0 entry blamed a `PackageManagerInternal.freeStorage` NPE. Both were symptoms of the same mis-configured AVD.

On targets: the AOSP repo stops at `android-36;default`, so none of the new levels has a `default` image. 36.1 and 37.0 use plain `google_apis`; 37.1 and 37.2 ship only the 16 KB page size variant. No `playstore` variant is usable because they block `adb root`, which minitouch needs.

The 37.2 betas are deliberately left out. GA supersedes them, and Google prunes beta images after GA, which would make the leg self-skip and report green with zero coverage.

All 20 legs pass, including the 16 pre-existing integer legs, so the update is confirmed to be a no-op for them: [full run](https://github.com/matanbaruch/stf/actions/runs/33636117893) (20 Android versions, 20 with a usable device in STF).

