### PR TITLE
Do not let one shutdown observer keep a unit alive

### DIFF
--- a/lib/util/lifecycle.js
+++ b/lib/util/lifecycle.js
@@ -4,9 +4,13 @@ var logger = require('./logger')
 var log = logger.createLogger('util:lifecycle')
 var _ = require('lodash')
 
+// How long the observers get in total before the process leaves without them
+var SHUTDOWN_TIMEOUT = 10000
+
 function Lifecycle() {
   this.observers = []
   this.ending = false
+  this.shutdownTimeout = SHUTDOWN_TIMEOUT
   process.on('SIGINT', this.graceful.bind(this))
   process.on('SIGTERM', this.graceful.bind(this))
 }
@@ -46,16 +50,29 @@ Lifecycle.prototype.share = function(name, emitter, options) {
   return emitter
 }
 
+// Runs every shutdown observer and resolves once they are all done with, however they end. One
+// observer that throws or never settles used to keep the whole unit alive; a shutdown is not the
+// place to insist every last thing succeeded.
+Lifecycle.prototype.settle = function() {
+  var timeout = this.shutdownTimeout
+
+  return Promise.all(this.observers.map(function(fn) {
+    return Promise.try(fn).catch(function(err) {
+      log.error('Shutdown observer failed', err && err.stack || err)
+    })
+  }))
+  .timeout(timeout)
+  .catch(Promise.TimeoutError, function() {
+    log.warn('Shutdown observers did not finish in %dms; exiting anyway', timeout)
+  })
+}
+
 Lifecycle.prototype.graceful = function() {
   log.info('Winding down for graceful exit')
 
   this.ending = true
 
-  var wait = Promise.all(this.observers.map(function(fn) {
-    return fn()
-  }))
-
-  return wait.then(function() {
+  return this.settle().then(function() {
     process.exit(0)
   })
 }

--- a/test/util/lifecycle.js
+++ b/test/util/lifecycle.js
@@ -1,0 +1,76 @@
+var chai = require('chai')
+var expect = chai.expect
+
+var lifecycle = require('../../lib/util/lifecycle')
+
+describe('lifecycle', function() {
+  describe('settle', function() {
+    var observers
+    var timeout
+    var write
+
+    beforeEach(function() {
+      observers = lifecycle.observers
+      timeout = lifecycle.shutdownTimeout
+      lifecycle.observers = []
+      lifecycle.shutdownTimeout = 200
+      // These cases log on purpose, and the report is easier to read without it
+      write = console.error
+      console.error = function() {}
+    })
+
+    afterEach(function() {
+      console.error = write
+      lifecycle.observers = observers
+      lifecycle.shutdownTimeout = timeout
+    })
+
+    it('should run every observer', function() {
+      var ran = []
+      lifecycle.observe(function() { ran.push('one') })
+      lifecycle.observe(function() { return Promise.resolve(ran.push('two')) })
+
+      return lifecycle.settle().then(function() {
+        expect(ran).to.eql(['one', 'two'])
+      })
+    })
+
+    // A unit that cannot shut down is worse than one that shuts down untidily, so each of these
+    // has to leave rather than hold the process open
+    it('should settle when an observer throws', function() {
+      lifecycle.observe(function() { throw new Error('sync') })
+      return lifecycle.settle()
+    })
+
+    it('should settle when an observer rejects', function() {
+      lifecycle.observe(function() { return Promise.reject(new Error('async')) })
+      return lifecycle.settle()
+    })
+
+    it('should give up on an observer that never settles', function() {
+      var started = Date.now()
+      var finished = false
+      lifecycle.observe(function() {
+        return new Promise(function() {}).then(function() { finished = true })
+      })
+
+      return lifecycle.settle().then(function() {
+        // Wide on purpose. What matters is that it waited rather than skipping, and left rather
+        // than hanging; pinning it to the exact timeout only buys a test that fails on a slow
+        // runner or a millisecond of timer slop.
+        expect(Date.now() - started).to.be.within(100, 2000)
+        expect(finished).to.equal(false)
+      })
+    })
+
+    it('should still run the others when one of them fails', function() {
+      var ran = []
+      lifecycle.observe(function() { throw new Error('sync') })
+      lifecycle.observe(function() { ran.push('after') })
+
+      return lifecycle.settle().then(function() {
+        expect(ran).to.eql(['after'])
+      })
+    })
+  })
+})


### PR DESCRIPTION
`graceful()` ran its shutdown observers through a bare `Promise.all` with no per-observer catch and no timeout, so one observer that throws, or never settles, leaves the process running instead of exiting.

A unit that cannot shut down is worse than one that shuts down untidily.

Each observer now runs for its effect with its failure logged rather than propagated, and the set as a whole is bounded at 10s, after which the process leaves without them. The waiting is split out as `settle()` so it can be tested without `process.exit` in the way.

`fatal()` is deliberately untouched. It still exits immediately without running observers.

## Tested

Adds `test/util/lifecycle.js`, the first coverage this file has had: 5 specs over `settle()`. Reverting the fix fails 4 of them.
