### PR TITLE
Clear ready when a device goes absent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
           key: ${{ needs.build.outputs.cache-key }}
           fail-on-cache-miss: true
 
-      - name: mocha (lib/util, lib/wire)
+      - name: mocha unit specs
         id: unit
         run: npm run test:unit
 
@@ -201,7 +201,7 @@ jobs:
         if: always()
         run: |
           bash .github/scripts/verdict.sh unit 'Unit tests (mocha)' \
-            '${{ steps.unit.outcome || job.status }}' 'lib/util + lib/wire specs'
+            '${{ steps.unit.outcome || job.status }}' 'lib/util, lib/wire and lib/db specs'
 
       - name: Upload verdict
         if: always()

--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -1422,6 +1422,7 @@ dbapi.setDeviceAbsent = function(serial) {
   return db.run(r.table('devices').get(serial).update({
     present: false
   , presenceChangedAt: r.now()
+  , ready: false
   }))
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "bower install && not-in-install && gulp build || in-install",
     "local": "node lib/cli/index.js local",
     "lint": "gulp lint",
-    "test:unit": "mocha --reporter spec --recursive test/util test/wire",
+    "test:unit": "mocha --reporter spec --recursive test/util test/wire test/db",
     "test:component": "karma start res/test/karma.ci.conf.js --single-run"
   },
   "dependencies": {

--- a/test/db/api.js
+++ b/test/db/api.js
@@ -1,0 +1,41 @@
+var chai = require('chai')
+var expect = chai.expect
+
+// Stub the db module in the require cache before lib/db/api pulls it in: requiring it for real
+// connects to RethinkDB as it loads, and these tests only care about the document a write sends.
+// A built update term is [UPDATE, [[target], {document}]], so the document is the last argument.
+var dbPath = require.resolve('../../lib/db')
+var lastUpdate = null
+
+require.cache[dbPath] = {exports: {
+  run: function(query) {
+    lastUpdate = query.build()[1][1]
+    return Promise.resolve({skipped: 0})
+  }
+}}
+
+var dbapi = require('../../lib/db/api')
+
+describe('dbapi device presence', function() {
+  beforeEach(function() {
+    lastUpdate = null
+  })
+
+  describe('setDeviceAbsent', function() {
+    it('should clear ready so a departed device stops reporting itself as ready', function() {
+      dbapi.setDeviceAbsent('serial')
+      expect(lastUpdate.present).to.equal(false)
+      expect(lastUpdate.ready).to.equal(false)
+    })
+  })
+
+  describe('setDevicePresent', function() {
+    // Deliberately asymmetric: only a device worker reaching "Fully operational" may set ready,
+    // so marking a device present must not guess at it.
+    it('should not touch ready', function() {
+      dbapi.setDevicePresent('serial')
+      expect(lastUpdate.present).to.equal(true)
+      expect(lastUpdate).to.not.have.property('ready')
+    })
+  })
+})


### PR DESCRIPTION
Nothing clears `ready` when a device leaves, so the row reads `ready: true` for the whole time a device is away. It only goes false when a new worker re-registers, which on real hardware is some forty seconds into a reboot.

Anything polling the database or the API to decide whether a device is usable sees stale state for that entire window.

It is now cleared in the same write that marks the device absent, since that write already describes the departure.

Setting it stays asymmetric on purpose: `setDevicePresent` still does not touch `ready`, because only a worker reaching "Fully operational" may say a device is ready. A device that is present again is not yet usable.

## Tested

Adds `test/db`, the first specs against `lib/db`, and wires them into the unit job. 2 specs, one per direction. Dropping the fix fails the first.
