### PR TITLE
Collapse the owned-device preamble and the auto-group envelope

### DIFF
--- a/lib/units/api/controllers/user.js
+++ b/lib/units/api/controllers/user.js
@@ -64,47 +64,49 @@ function getUserDevices(req, res) {
     })
 }
 
-function getUserDeviceBySerial(req, res) {
-  var serial = req.swagger.params.serial.value
-  var fields = req.swagger.params.fields.value
-
-  dbapi.loadDevice(req.user.groups.subscribed, serial)
+// Every device endpoint below opens the same way: find a device this user can see, and refuse
+// unless they are the one using it. Only the wording of the refusal differs, so the 404, the 403
+// and the 500 are all the helper's to answer.
+function withOwnedDevice(req, res, serial, notOwnedMessage, handler) {
+  return dbapi.loadDevice(req.user.groups.subscribed, serial)
     .then(function(cursor) {
       cursor.next(function(err, device) {
         if (err) {
-          return res.status(404).json({
-            success: false
-          , description: 'Device not found'
-          })
+          apiutil.respond(res, 404, 'Device not found')
+          return
         }
 
         datautil.normalize(device, req.user)
         if (!deviceutil.isOwnedByUser(device, req.user)) {
-          return res.status(403).json({
-            success: false
-          , description: 'Device is not owned by you'
-          })
+          apiutil.respond(res, 403, notOwnedMessage)
+          return
         }
 
-        var responseDevice = device
-        if (fields) {
-          responseDevice = _.pick(device, fields.split(','))
-        }
-
-        return res.json({
-          success: true
-        , description: 'Controlled device information'
-        , device: responseDevice
-        })
+        handler(device)
       })
     })
     .catch(function(err) {
-      log.error('Failed to load device "%s": ', req.params.serial, err.stack)
-      res.status(500).json({
-        success: false
-      , description: 'Internal Server Error'
-      })
+      apiutil.internalError(res, 'Failed to load device "%s": ', serial, err.stack)
     })
+}
+
+function getUserDeviceBySerial(req, res) {
+  var serial = req.swagger.params.serial.value
+  var fields = req.swagger.params.fields.value
+
+  withOwnedDevice(req, res, serial, 'Device is not owned by you'
+  , function(device) {
+    var responseDevice = device
+    if (fields) {
+      responseDevice = _.pick(device, fields.split(','))
+    }
+
+    return res.json({
+      success: true
+    , description: 'Controlled device information'
+    , device: responseDevice
+    })
+  })
 }
 
 function addUserDevice(req, res) {
@@ -189,221 +191,143 @@ function addUserDevice(req, res) {
 function deleteUserDeviceBySerial(req, res) {
   var serial = req.swagger.params.serial.value
 
-  dbapi.loadDevice(req.user.groups.subscribed, serial)
-    .then(function(cursor) {
-      cursor.next(function(err, device) {
-        if (err) {
-          res.status(404).json({
-            success: false
-          , description: 'Device not found'
-          })
-          return
-        }
+  withOwnedDevice(req, res, serial, 'You cannot release this device. Not owned by you'
+  , function(device) {
+    var messageListener
 
-        datautil.normalize(device, req.user)
-        if (!deviceutil.isOwnedByUser(device, req.user)) {
-          res.status(403).json({
-            success: false
-          , description: 'You cannot release this device. Not owned by you'
-          })
-          return
-        }
+    // Timer will be called if no JoinGroupMessage is received till 5 seconds
+    var responseTimer = setTimeout(function() {
+      req.options.channelRouter.removeListener(wireutil.global, messageListener)
+      return res.status(504).json({
+          success: false
+        , description: 'Device is not responding'
+      })
+    }, 5000)
 
-        var messageListener
-
-        // Timer will be called if no JoinGroupMessage is received till 5 seconds
-        var responseTimer = setTimeout(function() {
+    messageListener = wirerouter()
+      .on(wire.LeaveGroupMessage, function(channel, message) {
+        if (message.serial === serial &&
+            (message.owner.email === req.user.email || req.user.privilege === 'admin')) {
+          clearTimeout(responseTimer)
           req.options.channelRouter.removeListener(wireutil.global, messageListener)
-          return res.status(504).json({
-              success: false
-            , description: 'Device is not responding'
+
+          res.json({
+            success: true
+          , description: 'Device successfully removed'
           })
-        }, 5000)
+        }
+      })
+      .handler()
 
-        messageListener = wirerouter()
-          .on(wire.LeaveGroupMessage, function(channel, message) {
-            if (message.serial === serial &&
-                (message.owner.email === req.user.email || req.user.privilege === 'admin')) {
-              clearTimeout(responseTimer)
-              req.options.channelRouter.removeListener(wireutil.global, messageListener)
+    req.options.channelRouter.on(wireutil.global, messageListener)
 
-              res.json({
-                success: true
-              , description: 'Device successfully removed'
-              })
+    req.options.push.send([
+      device.channel
+    , wireutil.envelope(
+        new wire.UngroupMessage(
+          wireutil.toDeviceRequirements({
+            serial: {
+              value: serial
+            , match: 'exact'
             }
           })
-          .handler()
-
-        req.options.channelRouter.on(wireutil.global, messageListener)
-
-        req.options.push.send([
-          device.channel
-        , wireutil.envelope(
-            new wire.UngroupMessage(
-              wireutil.toDeviceRequirements({
-                serial: {
-                  value: serial
-                , match: 'exact'
-                }
-              })
-            )
-          )
-        ])
-      })
-    })
-    .catch(function(err) {
-      log.error('Failed to load device "%s": ', req.params.serial, err.stack)
-      res.status(500).json({
-        success: false
-      , description: 'Internal Server Error'
-      })
-    })
+        )
+      )
+    ])
+  })
 }
 
 function remoteConnectUserDeviceBySerial(req, res) {
   var serial = req.swagger.params.serial.value
 
-  dbapi.loadDevice(req.user.groups.subscribed, serial)
-    .then(function(cursor) {
-      cursor.next(function(err, device) {
-        if (err) {
-          res.status(404).json({
-            success: false
-          , description: 'Device not found'
-          })
-          return
-        }
+  withOwnedDevice(req, res, serial, 'Device is not owned by you or is not available'
+  , function(device) {
+    var responseChannel = 'txn_' + uuid.v4()
+    req.options.sub.subscribe(responseChannel)
 
-	datautil.normalize(device, req.user)
-	if (!deviceutil.isOwnedByUser(device, req.user)) {
-          res.status(403).json({
-            success: false
-          , description: 'Device is not owned by you or is not available'
-          })
-          return
-        }
-
-        var responseChannel = 'txn_' + uuid.v4()
-        req.options.sub.subscribe(responseChannel)
-
-        var messageListener
+    var messageListener
 
 	// Timer will be called if no JoinGroupMessage is received till 5 seconds
-        var timer = setTimeout(function() {
-          req.options.channelRouter.removeListener(responseChannel, messageListener)
+    var timer = setTimeout(function() {
+      req.options.channelRouter.removeListener(responseChannel, messageListener)
+      req.options.sub.unsubscribe(responseChannel)
+      return res.status(504).json({
+          success: false
+        , description: 'Device is not responding'
+      })
+    }, 5000)
+
+    messageListener = wirerouter()
+      .on(wire.ConnectStartedMessage, function(channel, message) {
+        if (message.serial === serial) {
+          clearTimeout(timer)
           req.options.sub.unsubscribe(responseChannel)
-          return res.status(504).json({
-              success: false
-            , description: 'Device is not responding'
+          req.options.channelRouter.removeListener(responseChannel, messageListener)
+          res.json({
+            success: true
+          , description: 'Remote connection is enabled'
+          , remoteConnectUrl: message.url
           })
-        }, 5000)
-
-        messageListener = wirerouter()
-          .on(wire.ConnectStartedMessage, function(channel, message) {
-            if (message.serial === serial) {
-              clearTimeout(timer)
-              req.options.sub.unsubscribe(responseChannel)
-              req.options.channelRouter.removeListener(responseChannel, messageListener)
-              res.json({
-                success: true
-              , description: 'Remote connection is enabled'
-              , remoteConnectUrl: message.url
-              })
-            }
-          })
-          .handler()
-
-        req.options.channelRouter.on(responseChannel, messageListener)
-
-        req.options.push.send([
-          device.channel
-        , wireutil.transaction(
-            responseChannel
-          , new wire.ConnectStartMessage()
-          )
-        ])
+        }
       })
-    })
-    .catch(function(err) {
-      log.error('Failed to load device "%s": ', req.params.serial, err.stack)
-      res.status(500).json({
-        success: false
-      , description: 'Internal Server Error'
-      })
-    })
+      .handler()
+
+    req.options.channelRouter.on(responseChannel, messageListener)
+
+    req.options.push.send([
+      device.channel
+    , wireutil.transaction(
+        responseChannel
+      , new wire.ConnectStartMessage()
+      )
+    ])
+  })
 }
 
 function remoteDisconnectUserDeviceBySerial(req, res) {
   var serial = req.swagger.params.serial.value
 
-  dbapi.loadDevice(req.user.groups.subscribed, serial)
-    .then(function(cursor) {
-      cursor.next(function(err, device) {
-        if (err) {
-          res.status(404).json({
-            success: false
-          , description: 'Device not found'
-          })
-          return
-        }
+  withOwnedDevice(req, res, serial, 'Device is not owned by you or is not available'
+  , function(device) {
+    var responseChannel = 'txn_' + uuid.v4()
+    req.options.sub.subscribe(responseChannel)
 
-        datautil.normalize(device, req.user)
-        if (!deviceutil.isOwnedByUser(device, req.user)) {
-          res.status(403).json({
-            success: false
-          , description: 'Device is not owned by you or is not available'
-          })
-          return
-        }
+    var messageListener
 
-        var responseChannel = 'txn_' + uuid.v4()
-        req.options.sub.subscribe(responseChannel)
-
-        var messageListener
-
-        // Timer will be called if no JoinGroupMessage is received till 5 seconds
-        var timer = setTimeout(function() {
-          req.options.channelRouter.removeListener(responseChannel, messageListener)
-          req.options.sub.unsubscribe(responseChannel)
-          return res.status(504).json({
-            success: false
-          , description: 'Device is not responding'
-          })
-        }, 5000)
-
-        messageListener = wirerouter()
-          .on(wire.ConnectStoppedMessage, function(channel, message) {
-            if (message.serial === serial) {
-              clearTimeout(timer)
-              req.options.sub.unsubscribe(responseChannel)
-              req.options.channelRouter.removeListener(responseChannel, messageListener)
-              res.json({
-                success: true
-              , description: 'Device remote disconnected successfully'
-              })
-            }
-          })
-          .handler()
-
-        req.options.channelRouter.on(responseChannel, messageListener)
-
-        req.options.push.send([
-          device.channel
-        , wireutil.transaction(
-            responseChannel
-          , new wire.ConnectStopMessage()
-          )
-        ])
-      })
-    })
-    .catch(function(err) {
-      log.error('Failed to load device "%s": ', req.params.serial, err.stack)
-      res.status(500).json({
+    // Timer will be called if no JoinGroupMessage is received till 5 seconds
+    var timer = setTimeout(function() {
+      req.options.channelRouter.removeListener(responseChannel, messageListener)
+      req.options.sub.unsubscribe(responseChannel)
+      return res.status(504).json({
         success: false
-      , description: 'Internal Server Error'
+      , description: 'Device is not responding'
       })
-    })
+    }, 5000)
+
+    messageListener = wirerouter()
+      .on(wire.ConnectStoppedMessage, function(channel, message) {
+        if (message.serial === serial) {
+          clearTimeout(timer)
+          req.options.sub.unsubscribe(responseChannel)
+          req.options.channelRouter.removeListener(responseChannel, messageListener)
+          res.json({
+            success: true
+          , description: 'Device remote disconnected successfully'
+          })
+        }
+      })
+      .handler()
+
+    req.options.channelRouter.on(responseChannel, messageListener)
+
+    req.options.push.send([
+      device.channel
+    , wireutil.transaction(
+        responseChannel
+      , new wire.ConnectStopMessage()
+      )
+    ])
+  })
 }
 
 function getUserAccessTokens(req, res) {

--- a/lib/units/processor/index.js
+++ b/lib/units/processor/index.js
@@ -58,6 +58,22 @@ module.exports = db.ensureConnectivity(function(options) {
     lifecycle.fatal()
   })
 
+  // Puts a device into a user's group without them asking, for the two cases where the system
+  // already knows who it belongs to: an adb fingerprint and a VNC auth response.
+  function sendAutoGroup(deviceChannel, user, identifier) {
+    devDealer.send([
+      deviceChannel
+    , wireutil.envelope(new wire.AutoGroupMessage(
+        new wire.OwnerMessage(
+          user.email
+        , user.name
+        , user.group
+        )
+      , identifier
+      ))
+    ])
+  }
+
   devDealer.on('message', wirerouter()
     .on(wire.UpdateAccessTokenMessage, function(channel, message, data) {
       appDealer.send([channel, data])
@@ -163,17 +179,7 @@ module.exports = db.ensureConnectivity(function(options) {
       dbapi.lookupUserByAdbFingerprint(message.fingerprint)
         .then(function(user) {
           if (user) {
-            devDealer.send([
-              channel
-            , wireutil.envelope(new wire.AutoGroupMessage(
-                new wire.OwnerMessage(
-                  user.email
-                , user.name
-                , user.group
-                )
-              , message.fingerprint
-              ))
-            ])
+            sendAutoGroup(channel, user, message.fingerprint)
           }
           else if (message.currentGroup) {
             appDealer.send([
@@ -198,17 +204,7 @@ module.exports = db.ensureConnectivity(function(options) {
       dbapi.lookupUserByVncAuthResponse(message.response, message.serial)
         .then(function(user) {
           if (user) {
-            devDealer.send([
-              channel
-            , wireutil.envelope(new wire.AutoGroupMessage(
-                new wire.OwnerMessage(
-                  user.email
-                , user.name
-                , user.group
-                )
-              , message.response
-              ))
-            ])
+            sendAutoGroup(channel, user, message.response)
           }
           else if (message.currentGroup) {
             appDealer.send([


### PR DESCRIPTION
Four device endpoints in `controllers/user.js` open with the same twenty-odd lines: load a device this user can see, 404 if there is none, normalize, then 403 unless they are the one using it. Each then trails a byte-identical 500 handler.

Only the wording of the 403 differs, so a change to any of those three contracts is a four-site edit.

They now share `withOwnedDevice`, which owns the 404, the 403 and the 500. Each endpoint passes the wording of its own refusal and supplies just its body.

`AutoGroupMessage` was likewise built twice in `processor/index.js`, for an adb fingerprint and for a VNC auth response. Same envelope, same owner, only the identifier differing, so they share `sendAutoGroup`.

## No behaviour change

The responses, status codes and refusal messages are the ones each endpoint already sent. One deliberate difference: the 500 now logs the serial the endpoint resolved rather than `req.params.serial`, which swagger routing does not fill in.

## Tested

All four endpoints exercised against a real device (Samsung Galaxy A02s over USB) owned, not owned, and on an unknown serial.

| endpoint | not owned | owned | unknown serial |
|---|---|---|---|
| `GET /user/devices/{serial}` | 403 | 200 | 404 |
| `POST /user/devices/{serial}/remoteConnect` | 403 | 200 | |
| `DELETE /user/devices/{serial}/remoteConnect` | 403 | 200 | |
| `DELETE /user/devices/{serial}` | 403 | 200 | |

Each 403 kept its own wording. Lint and the mocha unit tier pass.
