### PR TITLE
Pull docker.io base images through mirror.gcr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright © 2022-2024 contains code contributed by Orange SA, authors: Denis Barbaron - Licensed under the Apache license 2.0
 #
 
-FROM ubuntu:22.04
+FROM mirror.gcr.io/library/ubuntu:22.04
 
 # Sneak the stf executable into $PATH.
 ENV PATH=/app/bin:$PATH

--- a/Dockerfile-debian-x86_64
+++ b/Dockerfile-debian-x86_64
@@ -2,7 +2,7 @@
 # Copyright © 2020-2024 code initially contributed by Orange SA, authors: Denis Barbaron - Licensed under the Apache license 2.0
 #
 
-FROM debian:bookworm-slim
+FROM mirror.gcr.io/library/debian:bookworm-slim
 
 LABEL Maintainer="Denis Barbaron <denis.barbaron@orange.com>"
 LABEL Name="STF"


### PR DESCRIPTION
Fixes the Docker publish path from #927, which fails on the base image pull rather than the push.

## What breaks

On a push to master, `docker-build.yml` logs in to Docker Hub with the OIDC token, then buildkit reuses that token to pull `ubuntu:22.04`:

```
#3 [internal] load metadata for docker.io/library/ubuntu:22.04
#3 ERROR: failed to authorize: failed to fetch oauth token:
401 Unauthorized: access token has insufficient scopes
(scope=repository:library/ubuntu:pull)
```

The token is scoped to push `devicefarmer/stf`, so it cannot pull an unrelated public image. Pull requests gate the login behind `if: inputs.push`, so the base pull there is anonymous and green, which is why this only shows up on master: https://github.com/DeviceFarmer/stf/actions/runs/34061814733

Left as is, every merge to master fails `docker.yml` and stops updating `latest`, and a first `Release` half publishes: npm, the tag and the GitHub release land while the image does not.

## The change

Pull the base from `mirror.gcr.io`, a pull-through cache for Docker Hub, so the base never goes through `docker.io` and the scoped token is never used for it:

```dockerfile
FROM mirror.gcr.io/library/ubuntu:22.04
```

The push still targets `docker.io` authenticated. This is in the Dockerfile rather than in buildkit config, so the same base source applies wherever the image is built, not only in CI. It covers the two images the workflows build, the standard ubuntu one and `Dockerfile-debian-x86_64`. The arm and alpine variants are not built by any workflow, so they are left on their current bases.

There is a no code alternative discussed on #926: broadening the OIDC connection so its token can also read public repositories. If that is preferable and the connection allows it, this PR can be dropped.

## Verified

- `mirror.gcr.io` serves `library/ubuntu:22.04` and `library/debian:bookworm-slim` via `docker buildx imagetools inspect`.
- `FROM mirror.gcr.io/library/ubuntu:22.04` builds, logged out of Docker Hub, resolving the base at the digest the mirror serves.

## Not proven here

The failing path only exists with `push: true`, which CI on a pull request never sets. Like the code it fixes, this is confirmed by the next push to master rather than by this PR's checks.
