### PR TITLE
Save logs in the format the save-log modal shows

### DIFF
--- a/res/app/components/stf/common-ui/modals/save-log-modal/save-log-service.js
+++ b/res/app/components/stf/common-ui/modals/save-log-modal/save-log-service.js
@@ -4,7 +4,6 @@ module.exports =
   function SaveLogsServiceFactory($uibModal, $location, $route) {
     var SaveLogService = {}
     var logExtentension = ['json', 'log']
-    var selectedExtension = logExtentension[0]
 
     function parseLogsToDefinedExtenstion(device, logExtension, lineLimitation) {
       var lineLimiter = ((isNaN(lineLimitation)) ? device.length : lineLimitation)
@@ -72,27 +71,17 @@ module.exports =
       }
 
       $scope.saveLogs = function() {
-        var parsedOutput = NaN
+        var selectedExtension = $scope.selectedExtension
+        var parsedLogs = parseLogsToDefinedExtenstion(device, selectedExtension)
+        var parsedOutput
 
-        switch(selectedExtension) {
-          case 'json':
-              parsedOutput = new Blob(
-                [JSON.stringify(parseLogsToDefinedExtenstion(device, selectedExtension))],
-                {type: 'application/json;charset=utf-8'})
-              break
-          case 'log':
-              parsedOutput = new Blob(
-                [parseLogsToDefinedExtenstion(device, selectedExtension)],
-                {type: 'text/plain;charset=utf-8'})
-              break
-          default:
-              // ToDo
-              // Add support for other types
-              // Ad-hoc save file as plain text
-              parsedOutput = new Blob(
-                [parseLogsToDefinedExtenstion(device, selectedExtension)],
-                {type: 'text/plain;charset=utf-8'})
-              break
+        if (selectedExtension === 'json') {
+          parsedOutput = new Blob([JSON.stringify(parsedLogs)],
+            {type: 'application/json;charset=utf-8'})
+        }
+        else {
+          parsedOutput = new Blob([parsedLogs],
+            {type: 'text/plain;charset=utf-8'})
         }
 
         if (typeof $scope.saveLogFileName === 'undefined' ||
@@ -109,7 +98,6 @@ module.exports =
 
       $scope.$watch('selectedExtension', function(newValue, oldValue) {
         if (newValue !== oldValue) {
-          selectedExtension = newValue
           createSamplePresentation(device, newValue, $scope)
         }
       })

--- a/res/app/components/stf/common-ui/modals/save-log-modal/save-log-service.js
+++ b/res/app/components/stf/common-ui/modals/save-log-modal/save-log-service.js
@@ -6,7 +6,8 @@ module.exports =
     var logExtentension = ['json', 'log']
 
     function parseLogsToDefinedExtenstion(device, logExtension, lineLimitation) {
-      var lineLimiter = ((isNaN(lineLimitation)) ? device.length : lineLimitation)
+      var requestedLines = isNaN(lineLimitation) ? device.length : lineLimitation
+      var lineLimiter = Math.min(requestedLines, device.length)
       var output = ''
       if (device.length > 0) {
         if (logExtension === 'log') {

--- a/res/app/components/stf/common-ui/modals/save-log-modal/save-log-spec.js
+++ b/res/app/components/stf/common-ui/modals/save-log-modal/save-log-spec.js
@@ -1,9 +1,105 @@
+var FileSaver = require('file-saver')
+
 describe('SaveLogService', function() {
   beforeEach(angular.mock.module(require('./').name))
 
-  it('should ...', inject(function() {
+  var service, modal, controller, rootScope, capturedCtrl
 
-	// expect(SaveLogService.doSomething()).toEqual('something');
+  var fakeDevice = [
+    {
+      date: '01-01 00:00:00.000'
+      , pid: '1234'
+      , tag: 'ActivityManager'
+      , priorityLabel: 'I'
+      , message: 'first line'
+      , deviceLabel: 'Android'
+      , serial: 'serial-1'
+    }
+    , {
+      date: '01-01 00:00:01.000'
+      , pid: '1235'
+      , tag: 'Zygote'
+      , priorityLabel: 'W'
+      , message: 'second line'
+    }
+    , {
+      date: '01-01 00:00:02.000'
+      , pid: '1236'
+      , tag: 'WindowManager'
+      , priorityLabel: 'E'
+      , message: 'third line'
+    }
+    , {
+      date: '01-01 00:00:03.000'
+      , pid: '1237'
+      , tag: 'PackageManager'
+      , priorityLabel: 'D'
+      , message: 'fourth line'
+    }
+  ]
 
+  beforeEach(inject(function(SaveLogService, $uibModal, $controller, $rootScope) {
+    service = SaveLogService
+    modal = $uibModal
+    controller = $controller
+    rootScope = $rootScope
+
+    spyOn(modal, 'open').and.returnValue({result: {then: angular.noop}})
+    spyOn(FileSaver, 'saveAs')
+
+    service.open(fakeDevice, false)
+    capturedCtrl = modal.open.calls.mostRecent().args[0].controller
   }))
+
+  function openModal() {
+    var scope = rootScope.$new()
+    controller(capturedCtrl, {
+      $scope: scope
+      , $uibModalInstance: {
+        close: jasmine.createSpy('close')
+        , dismiss: jasmine.createSpy('dismiss')
+      }
+      , device: fakeDevice
+    })
+    scope.$digest()
+    return scope
+  }
+
+  function lastSave() {
+    return FileSaver.saveAs.calls.mostRecent().args
+  }
+
+  it('should reset a reopened modal to the format its dropdown shows', function() {
+    var first = openModal()
+    first.selectedExtension = 'log'
+    first.$digest()
+    first.saveLogs()
+
+    var second = openModal()
+    second.saveLogs()
+
+    expect(second.selectedExtension).toEqual('json')
+    expect(lastSave()[0].type).toEqual('application/json;charset=utf-8')
+    expect(lastSave()[1]).toMatch(/\.json$/)
+  })
+
+  it('should save plain text when the log format is chosen', function() {
+    var scope = openModal()
+    scope.selectedExtension = 'log'
+    scope.$digest()
+    scope.saveLogs()
+
+    expect(lastSave()[0].type).toEqual('text/plain;charset=utf-8')
+    expect(lastSave()[1]).toMatch(/\.log$/)
+  })
+
+  it('should append the chosen extension to a custom file name', function() {
+    var scope = openModal()
+    scope.saveLogFileName = 'my-logs'
+    scope.selectedExtension = 'log'
+    scope.$digest()
+    scope.saveLogs()
+
+    expect(lastSave()[1]).toEqual('my-logs.log')
+  })
 })

--- a/res/app/components/stf/common-ui/modals/save-log-modal/save-log-spec.js
+++ b/res/app/components/stf/common-ui/modals/save-log-modal/save-log-spec.js
@@ -51,7 +51,7 @@ describe('SaveLogService', function() {
     capturedCtrl = modal.open.calls.mostRecent().args[0].controller
   }))
 
-  function openModal() {
+  function openModal(device) {
     var scope = rootScope.$new()
     controller(capturedCtrl, {
       $scope: scope
@@ -59,7 +59,7 @@ describe('SaveLogService', function() {
         close: jasmine.createSpy('close')
         , dismiss: jasmine.createSpy('dismiss')
       }
-      , device: fakeDevice
+      , device: device || fakeDevice
     })
     scope.$digest()
     return scope
@@ -91,6 +91,17 @@ describe('SaveLogService', function() {
 
     expect(lastSave()[0].type).toEqual('text/plain;charset=utf-8')
     expect(lastSave()[1]).toMatch(/\.log$/)
+  })
+
+  it('should preview a log shorter than the sample line count', function() {
+    var scope = openModal(fakeDevice.slice(0, 2))
+
+    expect(JSON.parse(scope.samplePresentation).logs.length).toEqual(2)
+
+    scope.selectedExtension = 'log'
+    scope.$digest()
+
+    expect(scope.samplePresentation.split('\n').filter(Boolean).length).toEqual(2)
   })
 
   it('should append the chosen extension to a custom file name', function() {


### PR DESCRIPTION
Pick `log` in the save-log modal, save, then reopen it. The dropdown reads `json`, but pressing Save still writes a `.log` file with `text/plain` content.

`SaveLogService` is an Angular factory, so it is a singleton, and `selectedExtension` was declared at factory scope:

```js
function SaveLogsServiceFactory($uibModal, $location, $route) {
  var SaveLogService = {}
  var logExtentension = ['json', 'log']
  var selectedExtension = logExtentension[0]
```

That variable outlived every modal instance. Each modal reset only the scope copy, `$scope.selectedExtension = $scope.logExtentension[0]`, while `saveLogs()` read the factory one. The `$watch` that syncs them is guarded by `newValue !== oldValue`, so it never fires for the initial value. So the second modal shows `json` and saves `log`.

`saveLogs()` now reads `$scope.selectedExtension`, which is the format the user is actually looking at, and the factory-scope variable is gone. The `$watch` keeps its `createSamplePresentation` call, so the live preview is unchanged.

Reachable from the real UI: `res/app/components/stf/logcat-table/logcat-table-directive.js:203` calls `SaveLogService.open(collectedLogs, false)`.

## The switch collapse

This also closes the `// ToDo` / `// Add support for other types` marker that sat in the `switch`. `logExtentension` is `['json', 'log']` and the `<select>` in `save-log.pug` is bound to that array, so the `default` branch was unreachable, and its body was byte-identical to `case 'log'`. With the dead branch gone, json is the only special case, so an if/else says the same thing. Behaviour for both real values is preserved: `json` gives `JSON.stringify(...)` with `application/json;charset=utf-8`, `log` gives the raw string with `text/plain;charset=utf-8`. The filename logic is untouched apart from reading the right extension.

## Tests

The stub `save-log-spec.js` is replaced with three real specs. `ModalInstanceCtrl` is a closure and is not exported, so the spec captures it by spying on `$uibModal.open` and reading the `controller` option off the recorded call, then instantiates it twice from the same injector, which is what makes it a singleton test.

`npm run test:component`, measured on Node 22.11.0:

| | count |
| --- | --- |
| master at e5998fc | 118 of 118 |
| this branch | 121 of 121 |

121 is 118, minus the one vacuous `it()` that was replaced, plus four specs.

With master's `save-log-service.js` restored and the new specs kept, exactly 1 of 121 fails:

```
SaveLogService should reset a reopened modal to the format its dropdown shows FAILED
  Error: Expected 'text/plain;charset=utf-8' to equal 'application/json;charset=utf-8'.
  Error: Expected 'context.html_logs.log' to match /\.json$/.
```

The other two specs pass on master by design, since each `it` gets a fresh injector and the singleton never carries state into them. One detail worth flagging for review: the helper digests once at instantiation before any spec sets `log`. That is deliberate. Angular's initial watch run passes `newValue === oldValue`, so the first digest fires the listener at `json` and the guard skips it. Without that separate first digest, setting `log` before the first digest would arrive as `('log', 'log')`, the guard would swallow it, and the regression spec would pass on master for the wrong reason.

`npm run test:unit` stays at 104 passing, the same as master. `npm run lint` reports 0 errors and 0 warnings.

## The second bug, fixed in the second commit

`parseLogsToDefinedExtenstion` looped to `lineLimiter` without checking how many lines the device had collected, and `createSamplePresentation` asks it for a 4 line preview. Opening the modal on a device with fewer than 4 collected lines therefore threw out of the controller and the modal came up empty:

```
TypeError: Cannot read properties of undefined (reading 'date')
```

```js
var requestedLines = isNaN(lineLimitation) ? device.length : lineLimitation
var lineLimiter = Math.min(requestedLines, device.length)
```

Saving was never affected, since `saveLogs` passes no limit and already fell back to `device.length`. It is the preview alone that asked for more lines than existed.

The fourth spec opens the modal on a 2 line slice of the fixture and checks both formats, the json preview carrying 2 entries and the log preview 2 lines, so the one clamp is proved on both loops. Restoring the previous `parseLogsToDefinedExtenstion` and keeping the spec gives exactly 1 failure out of 121, reporting that same TypeError.
