### PR TITLE
Retry the flaky halves of CI instead of widening the token

### DIFF
--- a/.github/scripts/android-verdict.js
+++ b/.github/scripts/android-verdict.js
@@ -51,6 +51,17 @@ function main() {
     details = 'no published system image for API ' +
       (process.env.ANDROID_API || '?') + ' ' + (process.env.ANDROID_ARCH || '')
   }
+  else if (nothingRan && outcome === 'skipped') {
+    // A skipped emulator step did not run at all, so it cannot have timed out
+    // booting. Either the image probe said the image is unpublished -- handled
+    // above, because that path writes checks.json -- or a setup step earlier in
+    // the job failed and GitHub skipped everything after it. Blaming the
+    // emulator here sent three runs' worth of apt timeouts to the report as
+    // boot failures, so name the real shape of it instead.
+    status = 'fail'
+    details = 'the leg never got as far as the emulator: a setup step before ' +
+      'it failed, so the emulator step was skipped'
+  }
   else if (nothingRan) {
     // The leg script seeds every check before it does anything, so no checks at
     // all means the emulator step never handed control over: AVD creation or
@@ -88,8 +99,24 @@ function main() {
     }
   }
 
+  // A leg that only goes green the second time round is not the same signal as
+  // one that goes green the first time, so say which attempt this verdict is
+  // rather than letting the retry hide behind an ordinary tick.
+  var attempt = Number(process.env.LEG_ATTEMPT || 1)
+
+  if (attempt > 1) {
+    details += ' (attempt ' + attempt + ')'
+    if (status === 'pass') {
+      process.stdout.write('::warning::Android ' +
+        (process.env.ANDROID_VERSION || '?') + ' (API ' +
+        (process.env.ANDROID_API || '?') + ') failed once and passed on ' +
+        'attempt ' + attempt + '\n')
+    }
+  }
+
   var extra = {
     checks: checks
+  , attempt: attempt
   , android: process.env.ANDROID_VERSION || ''
   , api: process.env.ANDROID_API || ''
   , target: process.env.ANDROID_TARGET || ''

--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -8,6 +8,26 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
+# The runner image already ships a lot of this, and apt is the least reliable
+# thing in the job, so find out whether there is anything to do before touching
+# the network at all. The runtime legs usually ask for one package that is
+# missing and one that is not.
+missing=()
+for pkg in "$@"; do
+  if [ "$(dpkg-query -W -f='${db:Status-Status}' "$pkg" 2>/dev/null)" = 'installed' ]; then
+    echo "apt-install: ${pkg} is already installed"
+  else
+    missing+=("$pkg")
+  fi
+done
+
+if [ "${#missing[@]}" -eq 0 ]; then
+  echo "apt-install: nothing to install"
+  exit 0
+fi
+
+echo "apt-install: installing ${missing[*]}"
+
 # unattended-upgrades holds the dpkg lock on a freshly booted runner.
 sudo systemctl stop unattended-upgrades.service 2>/dev/null || true
 
@@ -16,15 +36,48 @@ if [ -f /etc/apt/apt-mirrors.txt ]; then
   sed 's/^/  /' /etc/apt/apt-mirrors.txt
 fi
 
+# Acquire::Retries is 1 on purpose. apt walks every suite against every mirror
+# in /etc/apt/apt-mirrors.txt, so a mirror that accepts the connection and then
+# stalls costs retries * suites * timeout. At Retries=3 that was 11m37s in run
+# 34600228545, which ran the 12 minute step budget out before the install below
+# was even reached and reported the leg as an emulator boot failure. Retrying
+# is done deliberately further down, around the install, which is the part that
+# actually has to succeed.
 APT_OPTS=(
   -o DPkg::Lock::Timeout=180
-  -o Acquire::Retries=3
-  -o Acquire::http::Timeout=20
-  -o Acquire::https::Timeout=20
+  -o Acquire::Retries=1
+  -o Acquire::http::Timeout=15
+  -o Acquire::https::Timeout=15
 )
 
-# A partial index refresh is usually enough to install from, so do not let a
-# flaky mirror fail the job here. The install below is what has to succeed.
-sudo apt-get "${APT_OPTS[@]}" update || echo "::warning::apt-get update did not complete cleanly, trying the install anyway"
+UPDATE_TIMEOUT="${APT_UPDATE_TIMEOUT:-120}"
 
-sudo apt-get "${APT_OPTS[@]}" install -y --no-install-recommends "$@"
+# A partial index refresh is usually enough to install from, and the indexes
+# baked into the image are days old at worst, so cap this instead of letting a
+# dead mirror eat the step. Run timeout under sudo so it can signal apt-get.
+apt_update() {
+  if sudo timeout "$UPDATE_TIMEOUT" apt-get "${APT_OPTS[@]}" update; then
+    return 0
+  fi
+  echo "::warning::apt-get update did not finish within ${UPDATE_TIMEOUT}s, installing from the indexes already on the image"
+  return 0
+}
+
+apt_update
+
+# A stale index is the one failure a plain retry cannot clear, because the
+# version apt resolved has already been superseded on the mirror and every
+# attempt 404s the same way. Refresh between the tries so the second one is
+# working from a different answer than the first.
+attempts=3
+attempt=1
+until sudo apt-get "${APT_OPTS[@]}" install -y --no-install-recommends "${missing[@]}"; do
+  if [ "$attempt" -ge "$attempts" ]; then
+    echo "::error::apt-get install failed after ${attempt} attempts: ${missing[*]}" >&2
+    exit 1
+  fi
+  echo "::warning::apt-get install attempt ${attempt} of ${attempts} failed, refreshing the indexes and retrying"
+  sleep $((attempt * 10))
+  apt_update
+  attempt=$((attempt + 1))
+done

--- a/.github/scripts/render-report.js
+++ b/.github/scripts/render-report.js
@@ -248,6 +248,21 @@ function main() {
     lines.push('')
   }
 
+  // A leg that only went green on its second attempt is still a flake, and a
+  // silent retry would turn a degrading emulator or test into a tick nobody
+  // ever looks at. Name them so the trend stays visible.
+  var retried = android.filter(function(v) {
+    return Number(v.attempt || 1) > 1
+  })
+  if (retried.length) {
+    lines.push('> :repeat: Retried once after failing: ' +
+      retried.map(function(v) {
+        return 'Android ' + v.android + ' (API ' + v.api + ', now ' +
+          v.status + ')'
+      }).join(', ') + '.')
+    lines.push('')
+  }
+
   var skipped = android.filter(function(v) {
     return v.checks && v.checks.image === 'skip'
   })

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Run a command until it succeeds, up to <attempts> times, backing off between
+# the tries.
+#
+# Every network-dependent setup step in this workflow has been seen to fail
+# transiently on a hosted runner: apt mirrors refuse the connection, the
+# Playwright CDN hands back a 5xx. None of them are the thing under test, so a
+# retry is the difference between a red run and a slightly slower one.
+#
+# usage: retry.sh <attempts> <command> [args...]
+#
+set -uo pipefail
+
+attempts="${1:-}"
+case "$attempts" in
+  '' | *[!0-9]*)
+    echo "usage: retry.sh <attempts> <command> [args...]" >&2
+    exit 2
+    ;;
+esac
+shift
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: retry.sh <attempts> <command> [args...]" >&2
+  exit 2
+fi
+
+status=1
+delay=5
+
+for attempt in $(seq 1 "$attempts"); do
+  # Read the status in the else branch. After a plain `if cmd; then ...; fi`
+  # whose condition failed, $? is the status of the `if` itself, which is 0,
+  # and the whole wrapper would then exit 0 on a command that never succeeded.
+  if "$@"; then
+    if [ "$attempt" -gt 1 ]; then
+      echo "retry.sh: succeeded on attempt ${attempt} of ${attempts}"
+    fi
+    exit 0
+  else
+    status=$?
+  fi
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "::warning::attempt ${attempt} of ${attempts} exited ${status}, retrying in ${delay}s: $*"
+    sleep "$delay"
+    delay=$((delay * 2))
+  fi
+done
+
+echo "::error::all ${attempts} attempts failed (exit ${status}): $*" >&2
+exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Every job that needs more than this says so itself. The report job already
+# scopes pull-requests: write to itself; widening it here would hand write
+# access to the seven job types that only ever read, the Android legs included.
+# It would not fix the 403 it looks like it fixes either: that one only happens
+# on pull requests from forks, where GitHub hands out a read-only token whatever
+# this block says.
 permissions:
   contents: read
 
@@ -373,11 +379,16 @@ jobs:
           node .github/scripts/stf-devices.js wait-count 2 120
           node .github/scripts/stf-devices.js list
 
+      # `playwright install --with-deps` shells out to apt for the browser
+      # libraries, so it inherits every apt flake the runtime steps have and
+      # reports it as a bare "Installation process exited with code: 100".
+      # Both halves are pure network, so retry rather than red the run.
       - name: Install Playwright
+        timeout-minutes: 15
         run: |
           cd test/playwright
-          npm install --no-audit --no-fund
-          npx playwright install --with-deps chromium
+          bash ../../.github/scripts/retry.sh 3 npm install --no-audit --no-fund
+          bash ../../.github/scripts/retry.sh 3 npx playwright install --with-deps chromium
 
       - name: Playwright web UI suite (no device)
         id: e2e
@@ -442,7 +453,10 @@ jobs:
     name: Android ${{ matrix.android }} (API ${{ matrix.api }})
     needs: [plan, build]
     runs-on: ubuntu-24.04
-    timeout-minutes: 75
+    # Room for two 50 minute emulator attempts plus the setup around them. A
+    # healthy leg spends under three minutes in the emulator step and never
+    # retries, so this ceiling is only ever paid by a leg that already failed.
+    timeout-minutes: 115
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -511,11 +525,16 @@ jobs:
           name: stf-bundle
           path: res/build
 
+      # `playwright install --with-deps` shells out to apt for the browser
+      # libraries, so it inherits every apt flake the runtime steps have and
+      # reports it as a bare "Installation process exited with code: 100".
+      # Both halves are pure network, so retry rather than red the run.
       - name: Install Playwright
+        timeout-minutes: 15
         run: |
           cd test/playwright
-          npm install --no-audit --no-fund
-          npx playwright install --with-deps chromium
+          bash ../../.github/scripts/retry.sh 3 npm install --no-audit --no-fund
+          bash ../../.github/scripts/retry.sh 3 npx playwright install --with-deps chromium
 
       - name: Wait for RethinkDB
         run: bash .github/scripts/wait-for-port.sh 28015 60 rethinkdb
@@ -622,6 +641,82 @@ jobs:
           EMULATOR_OUTCOME: ${{ steps.emulator.outcome }}
         run: node .github/scripts/android-verdict.js
 
+      # The matrix is 20 legs wide and every one of them gates the run, so a 1%
+      # per-leg flake rate reds one run in five however healthy STF is. Each
+      # failure mode seen so far -- a boot that ran out the clock, minicap
+      # frames that never reached the browser, a device STF never registered --
+      # passed on the next run of the same commit, so give the leg a second go
+      # and let that verdict stand.
+      #
+      # Gating on the verdict rather than on the emulator step's own outcome is
+      # deliberate: android-leg.sh never exits non-zero for a test failure, so
+      # the layer flakes all leave the step green. The plain `if` (no always())
+      # is deliberate too -- it keeps the retry from firing when a setup step
+      # earlier in the job failed, where there is nothing to retry and the
+      # apt-install and Playwright retries are the fix instead.
+      - name: Keep the first attempt before retrying
+        id: keep
+        if: steps.leg.outputs.status == 'fail'
+        # Through the environment, not interpolated into the shell string: the
+        # details come from a failing leg and end up inside double quotes.
+        env:
+          LEG_DETAILS: ${{ steps.leg.outputs.details }}
+        run: |
+          rm -rf stf-logs-attempt-1 checks-attempt-1.json
+          mv stf-logs stf-logs-attempt-1 2>/dev/null || true
+          mv checks.json checks-attempt-1.json 2>/dev/null || true
+          # A leg killed by the step timeout can leave the emulator alive, and a
+          # second one cannot bind the ports it is still holding.
+          adb kill-server 2>/dev/null || true
+          pkill -f qemu-system 2>/dev/null || true
+          # The retry costs no extra disk: the action creates the AVD as
+          # `avdmanager create --force -n test`, so the second attempt replaces
+          # the first one's 6G userdata rather than adding to it, and the system
+          # image is already downloaded. Print it anyway, because a retry that
+          # dies of a full disk would read as a leg that failed twice.
+          df -h /
+          echo "::warning::Android ${{ matrix.android }} (API ${{ matrix.api }}) failed: ${LEG_DETAILS}. Retrying once."
+
+      - name: Retry the leg once
+        id: emulator_retry
+        if: steps.keep.outcome == 'success'
+        continue-on-error: true
+        timeout-minutes: 50
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        env:
+          STF_LOG_DIR: stf-logs
+          STF_PUBLIC_IP: 127.0.0.1
+          CHECKS_FILE: checks.json
+          BOOT_TIMEOUT: ${{ matrix.boot }}
+        with:
+          api-level: ${{ matrix.api }}
+          target: ${{ matrix.target }}
+          channel: ${{ matrix.channel || 'stable' }}
+          arch: ${{ matrix.arch }}
+          profile: pixel_2
+          cores: 2
+          ram-size: 4096M
+          disk-size: 6G
+          emulator-boot-timeout: ${{ matrix.boot }}
+          disable-animations: true
+          emulator-options: >-
+            -no-window -gpu swiftshader_indirect -no-snapshot -noaudio
+            -no-boot-anim -camera-back none -camera-front none
+          script: bash .github/scripts/android-leg.sh
+
+      - name: Derive the verdict again
+        if: always() && steps.emulator_retry.outcome != 'skipped'
+        id: leg2
+        env:
+          CHECKS_FILE: checks.json
+          ANDROID_VERSION: ${{ matrix.android }}
+          ANDROID_API: ${{ matrix.api }}
+          ANDROID_TARGET: ${{ matrix.target }}
+          ANDROID_ARCH: ${{ matrix.arch }}
+          EMULATOR_OUTCOME: ${{ steps.emulator_retry.outcome }}
+          LEG_ATTEMPT: '2'
+        run: node .github/scripts/android-verdict.js
+
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v7
@@ -629,20 +724,25 @@ jobs:
           name: android-logs-api-${{ matrix.api }}-${{ matrix.target }}
           path: |
             stf-logs
+            stf-logs-attempt-1
             checks.json
+            checks-attempt-1.json
             test-results/playwright
           retention-days: 5
           if-no-files-found: warn
 
+      # The retried verdict wins when there is one. GitHub's `||` falls through
+      # on an empty string, so a leg that never retried reads its first verdict.
       - name: Record verdict
         if: always()
         env:
           VERDICT_GROUP: android
-          VERDICT_EXTRA: ${{ steps.leg.outputs.extra }}
+          VERDICT_EXTRA: ${{ steps.leg2.outputs.extra || steps.leg.outputs.extra }}
         run: |
           bash .github/scripts/verdict.sh 'android-${{ matrix.api }}' \
             'Android ${{ matrix.android }} (API ${{ matrix.api }})' \
-            '${{ steps.leg.outputs.status }}' '${{ steps.leg.outputs.details }}'
+            '${{ steps.leg2.outputs.status || steps.leg.outputs.status }}' \
+            '${{ steps.leg2.outputs.details || steps.leg.outputs.details }}'
 
       - name: Upload verdict
         if: always()

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -324,6 +324,44 @@ A job that dies before writing its verdict is reported as failed rather than
 disappearing from the table, which is what `EXPECTED_TIERS` and
 `EXPECTED_ANDROID_FILE` in the `report` job are for.
 
+## Flakes
+
+Every leg gates the run and the matrix is twenty legs wide, so per-leg flake
+rates multiply: a leg that fails one time in a hundred reds about one run in
+five no matter how healthy STF is. Two different mechanisms deal with that, and
+which one applies depends on whether the emulator was ever reached.
+
+**Before the emulator**, the setup steps retry in place. `apt-install.sh` skips
+packages that are already on the image, caps `apt-get update` at
+`APT_UPDATE_TIMEOUT` seconds (120 by default) because a stalling mirror will
+otherwise spend the whole step budget inside apt's own retries, and then retries
+the install three times, refreshing the indexes between the tries. The Playwright
+install is wrapped in `retry.sh`, since `playwright install --with-deps` shells
+out to apt as well and reports a failure there as a bare
+`Installation process exited with code: 100`.
+
+**From the emulator on**, the leg itself is retried once. The verdict is derived,
+and if it failed the leg runs a second time from a fresh AVD and the second
+verdict is the one recorded. The gate is the verdict rather than the emulator
+step's exit status on purpose: `android-leg.sh` never exits non-zero for a test
+failure, so a leg that booted and then lost its minicap stream leaves the step
+green and only the verdict knows it failed.
+
+A retry is never silent. The leg gets a warning annotation, its verdict details
+end in `(attempt 2)`, and the report prints a `Retried once after failing` line
+naming the leg and how it ended, so a leg that is quietly degrading still shows
+up instead of hiding behind a tick. The first attempt's logs are kept alongside
+the second's in the same artifact, as `stf-logs-attempt-1` and
+`checks-attempt-1.json`.
+
+The retry deliberately does not fire when a step before the emulator failed.
+There is nothing to retry in that case, and the in-step retries above are the
+fix. That case is also worth recognising in the report: an emulator step that
+was **skipped** cannot have timed out booting, so the verdict says the leg never
+got as far as the emulator rather than blaming the boot. Before that distinction
+existed, three runs' worth of apt timeouts were reported as emulator boot
+failures, which is a good way to spend an afternoon debugging the wrong thing.
+
 ## Debugging a failed leg
 
 Every leg uploads `android-logs-api-<api>-<target>` containing `stf local`'s


### PR DESCRIPTION
This PR started out adding `pull-requests: write` at the workflow level to stop
the report job's 403. That was the wrong diagnosis, so it now does something
else. The 403 analysis is kept below because it is the reason the real cause
went unnoticed.

## The 403 was never the problem

- **It never failed a build.** The `Upsert PR comment` step is
  `continue-on-error: true`, so a 403 there is reported as a *success*. That is
  also why #950 looked like it commented fine when it had 403'd too.
- **It only happens on fork PRs.** #952 and #950 came from a fork; their token
  reads `PullRequests: read`, `Secret source: None`. GitHub hands fork pull
  requests a read-only token whatever `permissions:` says, so no change here can
  fix it.
- **The `report` job already grants itself `pull-requests: write`.** A
  workflow-level grant is therefore a no-op for the one job that needs it, and a
  privilege widening for the seven that do not. Measured on the `Build` job:
  `Contents: read, Metadata: read` on master, plus `PullRequests: write` with the
  original version of this PR applied.
- **Decisive:** in run 34690485255 (this PR, the change in effect) the comment
  *succeeded* — `updated comment 5645517495` — and the build still went red.

## What was actually failing

19 of the last 100 CI runs failed. All of them failed in the same place,
`Report` → `Fail if any tier failed`, for different underlying reasons. About
half were flakes:

| Cause | Runs |
|---|---|
| `apt-get update` stalling on `archive.ubuntu.com` and blowing the 12 minute step budget — 11m37s of it inside apt's own retries | 3 legs / 2 runs |
| `playwright install --with-deps` → apt → `Installation process exited with code: 100` | 1 |
| Emulator never finished booting | 3 |
| No minicap frames / device never registered in STF | 2 |

The rest were genuine lint, unit and dependency-bump breakages, i.e. CI working.

The matrix is 20 legs wide and every leg gates the run, so a 1% per-leg flake
rate reds about one run in five however healthy STF is.

There was also a diagnosis bug that hid all of this: **`android-verdict.js`
reported the apt timeouts as "the emulator never finished booting"**. When a
setup step fails, GitHub skips every step after it, the emulator step never
runs, `checks.json` is never written, and the verdict blamed the boot.

## What this PR does

- **apt** (`apt-install.sh`) — skip packages already on the image, cap
  `apt-get update` at `APT_UPDATE_TIMEOUT` (120s) so a stalling mirror cannot eat
  the step, then retry the install three times, refreshing the indexes between
  tries. `Acquire::Retries` drops to 1 because apt's own retries are what burned
  the budget.
- **Playwright** — new `retry.sh` wraps both `npm install` and
  `playwright install --with-deps`.
- **Emulator legs** — a failed leg runs once more from a fresh AVD and the second
  verdict stands. Gated on the *verdict* rather than the emulator step's exit
  status, because `android-leg.sh` never exits non-zero for a test failure, so
  the layer flakes all leave the step green. Deliberately does not fire when a
  step before the emulator failed: there is nothing to retry there, and the
  in-step retries above are the fix.
- **Retries are never silent** — warning annotation, `(attempt 2)` in the
  verdict details, and a `Retried once after failing` line in the report, so a
  leg that is quietly degrading still shows up instead of hiding behind a tick.
  The first attempt's logs are kept beside the second's as `stf-logs-attempt-1`
  and `checks-attempt-1.json`.
- **Fixes the misattribution** — a *skipped* emulator step cannot have timed out
  booting, so the verdict now says the leg never got as far as the emulator.
- **Drops the workflow-level permission** and leaves a comment saying why, so the
  next person does not re-add it.
- Documents the lot in `doc/ci.md`.

The Android job's `timeout-minutes` goes 75 → 115 to fit two 50 minute emulator
attempts. A healthy leg spends under three minutes in that step and never
retries, so the ceiling is only ever paid by a leg that already failed. The retry
costs no extra disk either: the action creates the AVD as
`avdmanager create --force -n test`, so attempt 2 replaces attempt 1's 6G
userdata rather than adding to it, and the system image is already downloaded.

## Testing

Both verdict branches, `retry.sh`, `apt-install.sh` against a stubbed apt, and
the report pipeline end to end were exercised locally. That found a real bug in
the first draft of `retry.sh`: `$?` after a failed `if` is the status of the `if`
itself, which is 0, so the wrapper exited 0 on a command that never succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)